### PR TITLE
Don't copy created and updated timestamps to new resources

### DIFF
--- a/src/ducks/resource.js
+++ b/src/ducks/resource.js
@@ -98,6 +98,8 @@ function createTranslation(original, translations, type, language) {
     const newResource = Object.assign({}, original);
     delete newResource.id;
     delete newResource.href;
+    delete newResource.created_at;
+    delete newResource.updated_at;
     newResource.language = language;
     dispatch({
       type: CREATE_TRANSLATION,


### PR DESCRIPTION
Tiny fix. I forgot to remove the timestamps when I set up the `createTranslation` action.