### PR TITLE
[WIP]: Create and edit ProjectPage resources

### DIFF
--- a/src/components/ProjectPage.jsx
+++ b/src/components/ProjectPage.jsx
@@ -18,9 +18,9 @@ function ProjectPage(props) {
       <h2>Project Page</h2>
       <dl>
         <dt>title</dt>
-        <dd>{page.title}</dd>
+        <dd data-translation-key="title">{page.title}</dd>
         <dt>content</dt>
-        <dd>{page.content}</dd>
+        <dd data-translation-key="content">{page.content}</dd>
       </dl>
     </div>
   );

--- a/src/ducks/resource.js
+++ b/src/ducks/resource.js
@@ -41,6 +41,23 @@ function awaitTranslations(id, type, project) {
   }
 }
 
+function createResource(type, resource) {
+  switch (type) {
+    case 'project_pages':
+      // project pages have a different API endpoint from other resources
+      const project_id = resource.links.project;
+      return apiClient
+        .post(`/projects/${project_id}/pages`, { project_pages: resource })
+        .then(([page]) => page);
+      // TODO: organisation pages use /api/organisations/{id}/pages
+    default:
+      return apiClient
+        .type(type)
+        .create(resource)
+        .save();
+  }
+}
+
 // Reducer
 const initialState = {
   original: null,
@@ -106,9 +123,7 @@ function createTranslation(original, translations, type, language) {
       newResource,
       original
     });
-    apiClient.type(type)
-    .create(newResource)
-    .save()
+    createResource(type, newResource)
       .then((translation) => {
         translations.push(translation);
         dispatch({

--- a/src/ducks/resource.js
+++ b/src/ducks/resource.js
@@ -46,8 +46,9 @@ function createResource(type, resource) {
     case 'project_pages':
       // project pages have a different API endpoint from other resources
       const project_id = resource.links.project;
+      const { url_key, title, content, language } = resource;
       return apiClient
-        .post(`/projects/${project_id}/pages`, { project_pages: resource })
+        .post(`/projects/${project_id}/pages`, { project_pages: { url_key, title, content, language } })
         .then(([page]) => page);
       // TODO: organisation pages use /api/organisations/{id}/pages
     default:


### PR DESCRIPTION
Adds a helper because project pages use a different API route from other resources.

Adds translation keys so that page titles and contents can be editted.