### PR TITLE
Add custom port to webpack dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/zooniverse/pandora",
   "scripts": {
-    "start": "BABEL_ENV=development webpack-dashboard -- babel-node server.js",
+    "start": "BABEL_ENV=development webpack-dashboard -p 3001 -- babel-node server.js",
     "test": "NODE_ENV=development BABEL_ENV=test mocha $(find test -name *.test.jsx) --compilers js:babel-core/register || true",
     "test-travis": "NODE_ENV=development BABEL_ENV=test mocha $(find test -name *.test.jsx) --compilers js:babel-core/register",
     "eslint": "eslint .",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 /* eslint import/no-extraneous-dependencies: ["error", { "devDependencies": true  }] */
 const path = require('path');
 const webpack = require('webpack');
+const DashboardPlugin = require('webpack-dashboard/plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const nib = require('nib');
 
@@ -21,6 +22,7 @@ module.exports = {
   },
 
   plugins: [
+    new DashboardPlugin({ port: 3001 }),
     new HtmlWebpackPlugin({
       template: 'src/index.tpl.html',
       inject: 'body',


### PR DESCRIPTION
Useful for running other projects that have Webpack dashboard, notably PFE.