### PR TITLE
Language selector widget

### DIFF
--- a/src/components/LanguageSelector.jsx
+++ b/src/components/LanguageSelector.jsx
@@ -44,7 +44,7 @@ class LanguageSelector extends Component {
     return (
       <div>
         <h3>Pick a language</h3>
-        <ul>
+        <ul className="language-selector">
           {existingLanguages.map((option) => {
             return (
               <li key={option.value}>
@@ -56,7 +56,7 @@ class LanguageSelector extends Component {
                     value={option.value}
                     onChange={this.onLanguageChange}
                   />
-                  {option.label}
+                  <span>{option.label}</span>
                 </label>
               </li>
             );

--- a/src/components/LanguageSelector.jsx
+++ b/src/components/LanguageSelector.jsx
@@ -1,0 +1,91 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Select from 'grommet/components/Select';
+import languages from '../constants/languages';
+
+class LanguageSelector extends Component {
+  constructor() {
+    super();
+    this.handleSelect = this.handleSelect.bind(this);
+    this.handleSearch = this.handleSearch.bind(this);
+    this.onLanguageChange = this.onLanguageChange.bind(this);
+    this.state = {
+      newLanguages: []
+    }
+  }
+  
+  handleSearch(event) {
+    const searchStr = event.target.value;
+    if (searchStr) {
+      const matchesSearch = (langObj) => langObj.label.toLowerCase().substr(0, searchStr.length) === searchStr.toLowerCase();
+      const newLanguages = languages.filter(matchesSearch);
+      this.setState({ newLanguages });
+    }
+  }
+
+  handleSelect({ option }) {
+    this.props.onChange(option);
+  }
+
+  onLanguageChange(e) {
+    const { value } = e.target;
+    const [option] = languages.filter(option => option.value === value);
+    this.props.onChange(option);
+  }
+
+  render() {
+    const existingLanguages = [];
+    let menuLanguages = this.state.newLanguages.slice();
+    this.props.translations.map((translation) => {
+      const [languageOption] = languages.filter(option => option.value === translation.language);
+      existingLanguages.push(languageOption);
+      menuLanguages = menuLanguages.filter(option => option !== languageOption);
+    });
+    return (
+      <div>
+        <h3>Pick a language</h3>
+        <ul>
+          {existingLanguages.map((option) => {
+            return (
+              <li key={option.value}>
+                <label>
+                  <input
+                    name="lang"
+                    type="radio"
+                    checked={option.value === this.props.value.value}
+                    value={option.value}
+                    onChange={this.onLanguageChange}
+                  />
+                  {option.label}
+                </label>
+              </li>
+            );
+          })}
+        </ul>
+        <label>
+          or add a new language
+          <Select
+            onChange={this.handleSelect}
+            onSearch={this.handleSearch}
+            options={menuLanguages}
+            placeHolder="Select a language"
+            value={this.props.value}
+          />
+        </label>
+      </div>
+    );
+  }
+}
+
+LanguageSelector.propTypes = {
+  onChange: PropTypes.func,
+  translations: PropTypes.array
+};
+
+LanguageSelector.defaultProps = {
+  onChange: () => null,
+  translations: []
+};
+
+export default LanguageSelector;
+

--- a/src/components/ProjectDashboard.jsx
+++ b/src/components/ProjectDashboard.jsx
@@ -35,19 +35,9 @@ TutorialLink.propTypes = {
 };
 
 function ProjectDashboard(props) {
-  const { fieldguides, project, translations, tutorials, workflows } = props;
+  const { fieldguides, project, tutorials, workflows } = props;
   return (
     <div>
-      <h3>Translations</h3>
-      <ul>
-        {translations.map((translation) => {
-          return (
-            <li key={translation.id}>
-              {translation.language}
-            </li>
-          );
-        })}
-      </ul>
       <ProjectContentsContainer {...props}>
         <ProjectContents />
       </ProjectContentsContainer>

--- a/src/containers/ProjectDashboardContainer.jsx
+++ b/src/containers/ProjectDashboardContainer.jsx
@@ -76,39 +76,48 @@ class ProjectDashboardContainer extends Component {
     const project = this.props.project.data;
     const { fieldguides, pages, workflows, tutorials } = this.props.project;
     const { translations } = this.props.resource;
-    const options = this.getSelectOptions();
+    let newLanguages = this.getSelectOptions();
     const language = this.state.option.value;
+    const existingLanguages = [];
+    translations.map((translation) => {
+      const [languageOption] = languages.filter(option => option.value === translation.language);
+      existingLanguages.push(languageOption);
+      newLanguages = newLanguages.filter(option => option !== languageOption);
+    });
+    const selectedOption = newLanguages.indexOf(this.state.option) > -1 ? this.state.option : null;
+    
     return (
       <div>
         <h2>Project Dashboard</h2>
-        <Select
-          onChange={this.handleSelect}
-          onSearch={this.handleSearch}
-          options={options}
-          placeHolder="Select a language"
-          value={this.state.option}
-        />
-
-        <h3>Translations</h3>
+        <h3>Pick a language</h3>
         <ul>
-          {translations.map((translation) => {
-            const [{ value, label }] = languages.filter(option => option.value === translation.language);
+          {existingLanguages.map((option) => {
             return (
-              <li key={translation.id}>
+              <li key={option.value}>
                 <label>
                   <input
                     name="lang"
                     type="radio"
-                    checked={value === this.state.option.value}
-                    value={value}
+                    checked={option.value === this.state.option.value}
+                    value={option.value}
                     onChange={this.onLanguageChange}
                   />
-                  {label}
+                  {option.label}
                 </label>
               </li>
             );
           })}
         </ul>
+        <label>
+          or add a new language
+          <Select
+            onChange={this.handleSelect}
+            onSearch={this.handleSearch}
+            options={newLanguages}
+            placeHolder="Select a language"
+            value={selectedOption}
+          />
+        </label>
 
         {project.primary_language && React.cloneElement(this.props.children, { fieldguides, language, pages, project, tutorials, workflows })}
       </div>

--- a/src/containers/ProjectDashboardContainer.jsx
+++ b/src/containers/ProjectDashboardContainer.jsx
@@ -32,6 +32,7 @@ class ProjectDashboardContainer extends Component {
     super();
     this.handleSearch = this.handleSearch.bind(this);
     this.handleSelect = this.handleSelect.bind(this);
+    this.onLanguageChange = this.onLanguageChange.bind(this);
     this.state = {
       searchText: '',
       option: {},
@@ -53,6 +54,12 @@ class ProjectDashboardContainer extends Component {
     this.setState({
       option,
     });
+  }
+
+  onLanguageChange(e) {
+    const { value } = e.target;
+    const [option] = languages.filter(option => option.value === value);
+    this.handleSelect({ option });
   }
 
   getSelectOptions() {
@@ -85,10 +92,19 @@ class ProjectDashboardContainer extends Component {
         <h3>Translations</h3>
         <ul>
           {translations.map((translation) => {
-            const [language] = languages.filter(option => option.value === translation.language)
+            const [{ value, label }] = languages.filter(option => option.value === translation.language);
             return (
               <li key={translation.id}>
-                {language.label}
+                <label>
+                  <input
+                    name="lang"
+                    type="radio"
+                    checked={value === this.state.option.value}
+                    value={value}
+                    onChange={this.onLanguageChange}
+                  />
+                  {label}
+                </label>
               </li>
             );
           })}

--- a/src/containers/ProjectDashboardContainer.jsx
+++ b/src/containers/ProjectDashboardContainer.jsx
@@ -2,10 +2,9 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import languages from '../constants/languages';
+import LanguageSelector from '../components/LanguageSelector';
 import { fetchProject } from '../ducks/project';
 import { createTranslation } from '../ducks/resource';
-import Select from 'grommet/components/Select';
 
 const propTypes = {
   actions: PropTypes.object.isRequired,
@@ -30,95 +29,35 @@ const propTypes = {
 class ProjectDashboardContainer extends Component {
   constructor() {
     super();
-    this.handleSearch = this.handleSearch.bind(this);
-    this.handleSelect = this.handleSelect.bind(this);
-    this.onLanguageChange = this.onLanguageChange.bind(this);
+    this.onChangeLanguage = this.onChangeLanguage.bind(this);
     this.state = {
       searchText: '',
-      option: {},
+      option: {
+        label: '',
+        value: ''
+      },
     };
   }
+
   componentDidMount() {
     const { actions } = this.props;
     actions.fetchProject(this.props.params.project_id);
   }
 
-  handleSearch(event) {
-    this.setState({
-      searchText: event.target.value,
-    });
-  }
-
-  handleSelect({ option }) {
-    const { actions } = this.props;
-    this.setState({
-      option,
-    });
-  }
-
-  onLanguageChange(e) {
-    const { value } = e.target;
-    const [option] = languages.filter(option => option.value === value);
-    this.handleSelect({ option });
-  }
-
-  getSelectOptions() {
-    const searchStr = this.state.searchText;
-    let langs = languages.slice();
-    if (searchStr) {
-      const matchesSearch = (langObj) => langObj.label.toLowerCase().substr(0, searchStr.length) === searchStr;
-      langs = languages.filter(matchesSearch);
-    }
-    return langs;
+  onChangeLanguage(option) {
+    this.setState({ option });
   }
 
   render() {
     const project = this.props.project.data;
     const { fieldguides, pages, workflows, tutorials } = this.props.project;
     const { translations } = this.props.resource;
-    let newLanguages = this.getSelectOptions();
     const language = this.state.option.value;
-    const existingLanguages = [];
-    translations.map((translation) => {
-      const [languageOption] = languages.filter(option => option.value === translation.language);
-      existingLanguages.push(languageOption);
-      newLanguages = newLanguages.filter(option => option !== languageOption);
-    });
-    const selectedOption = newLanguages.indexOf(this.state.option) > -1 ? this.state.option : null;
     
     return (
       <div>
         <h2>Project Dashboard</h2>
-        <h3>Pick a language</h3>
-        <ul>
-          {existingLanguages.map((option) => {
-            return (
-              <li key={option.value}>
-                <label>
-                  <input
-                    name="lang"
-                    type="radio"
-                    checked={option.value === this.state.option.value}
-                    value={option.value}
-                    onChange={this.onLanguageChange}
-                  />
-                  {option.label}
-                </label>
-              </li>
-            );
-          })}
-        </ul>
-        <label>
-          or add a new language
-          <Select
-            onChange={this.handleSelect}
-            onSearch={this.handleSearch}
-            options={newLanguages}
-            placeHolder="Select a language"
-            value={selectedOption}
-          />
-        </label>
-
+        <LanguageSelector translations={translations} value={this.state.option} onChange={this.onChangeLanguage} />
         {project.primary_language && React.cloneElement(this.props.children, { fieldguides, language, pages, project, tutorials, workflows })}
       </div>
     );

--- a/src/containers/ProjectDashboardContainer.jsx
+++ b/src/containers/ProjectDashboardContainer.jsx
@@ -82,7 +82,18 @@ class ProjectDashboardContainer extends Component {
           value={this.state.option}
         />
 
-        {project.primary_language && React.cloneElement(this.props.children, { fieldguides, language, pages, project, translations, tutorials, workflows })}
+        <h3>Translations</h3>
+        <ul>
+          {translations.map((translation) => {
+            return (
+              <li key={translation.id}>
+                {translation.language}
+              </li>
+            );
+          })}
+        </ul>
+
+        {project.primary_language && React.cloneElement(this.props.children, { fieldguides, language, pages, project, tutorials, workflows })}
       </div>
     );
   }

--- a/src/containers/ProjectDashboardContainer.jsx
+++ b/src/containers/ProjectDashboardContainer.jsx
@@ -85,9 +85,10 @@ class ProjectDashboardContainer extends Component {
         <h3>Translations</h3>
         <ul>
           {translations.map((translation) => {
+            const [language] = languages.filter(option => option.value === translation.language)
             return (
               <li key={translation.id}>
-                {translation.language}
+                {language.label}
               </li>
             );
           })}

--- a/src/styles/components/language-selector.styl
+++ b/src/styles/components/language-selector.styl
@@ -1,0 +1,24 @@
+.language-selector
+  display: inline-block
+  list-style-type: none
+  margin: 0
+  text-indent: 0
+  
+  li
+    display: inline-block
+    
+    input[type=radio]
+      opacity: 0
+      width: 0
+    
+      & + span
+        background: #ddd
+        border: 1px solid grey
+        border-radius: .2em
+        color: grey
+        padding: .2em .5em
+        margin: .2em
+    
+      &:checked + span
+        border: 1px solid black
+        color: black


### PR DESCRIPTION
List existing translation languages in the container component.

TODO:
- [x] show language names, not language codes.
- [x] add radio buttons so that languages in the list can be selected.
- [x] return a `{value, label}` object from each selected language, so that it can use the same handler as the dropdown menu.
- [x] extract all this, plus the dropdown, into its own `LanguageSelector` component.