### PR TITLE
Reset resources before rendering

### DIFF
--- a/src/containers/ProjectContentsContainer.jsx
+++ b/src/containers/ProjectContentsContainer.jsx
@@ -9,6 +9,16 @@ import * as contentsActions from '../ducks/resource';
 import isElementTranslatable from '../helpers/isElementTranslatable';
 
 class ProjectContentsContainer extends Component {
+  static getTextFromPath(resource, path) {
+    path = path.split('.');
+    let text = resource;
+    while (path.length) {
+      text = text[path[0]];
+      path.shift();
+    }
+    return text;
+  }
+
   constructor() {
     super();
     this.closeModal = this.closeModal.bind(this);
@@ -47,16 +57,6 @@ class ProjectContentsContainer extends Component {
     }
   }
 
-  getTextFromPath(resource, path) {
-    path = path.split('.');
-    let text = resource;
-    while (path.length) {
-      text = text[path[0]];
-      path.shift();
-    }
-    return text;
-  }
-
   closeModal() {
     this.setState({ modalOpen: false });
   }
@@ -80,8 +80,8 @@ class ProjectContentsContainer extends Component {
           fieldText = original[field][subfield];
           translationText = translation[field][subfield];
         } else {
-          fieldText = this.getTextFromPath(original, field);
-          translationText = this.getTextFromPath(translation, field);
+          fieldText = ProjectContentsContainer.getTextFromPath(original, field);
+          translationText = ProjectContentsContainer.getTextFromPath(translation, field);
         }
         this.setState({
           field,

--- a/src/containers/ProjectContentsContainer.jsx
+++ b/src/containers/ProjectContentsContainer.jsx
@@ -26,6 +26,11 @@ class ProjectContentsContainer extends Component {
     };
   }
 
+  componentWillMount() {
+    const { actions } = this.props;
+    actions.resetTranslations();
+  }
+
   componentDidMount() {
     const { actions, params, project, language } = this.props;
     const type = params.resource_type;

--- a/src/ducks/resource.js
+++ b/src/ducks/resource.js
@@ -1,6 +1,7 @@
 import apiClient from 'panoptes-client/lib/api-client';
 
 // Action Types
+export const RESET_TRANSLATIONS = 'RESET_TRANSLATIONS';
 export const FETCH_TRANSLATIONS = 'FETCH_TRANSLATIONS';
 export const FETCH_TRANSLATIONS_SUCCESS = 'FETCH_TRANSLATIONS_SUCCESS';
 export const FETCH_TRANSLATIONS_ERROR = 'FETCH_TRANSLATIONS_ERROR';
@@ -56,6 +57,7 @@ const initialState = {
 
 const resourceReducer = (state = initialState, action) => {
   switch (action.type) {
+    case RESET_TRANSLATIONS:
     case FETCH_TRANSLATIONS:
       return Object.assign({}, initialState, { loading: true });
     case CREATE_TRANSLATION:
@@ -75,6 +77,14 @@ const resourceReducer = (state = initialState, action) => {
 };
 
 // Action Creators
+function resetTranslations() {
+  return (dispatch) => {
+    dispatch({
+      type: RESET_TRANSLATIONS
+    });
+  };
+}
+
 function fetchTranslations(id, type, project, language) {
   type = type || 'projects';
   return (dispatch) => {
@@ -167,5 +177,6 @@ export {
   createTranslation,
   selectTranslation,
   updateTranslation,
-  fetchTranslations
+  fetchTranslations,
+  resetTranslations
 };


### PR DESCRIPTION
Resets resource translations back to initial state before rendering the editor components.

Fixes a static method that was defined as a class method in `ProjectContentsContainer`.