### PR TITLE
Language params

### DIFF
--- a/src/components/LanguageSelector.jsx
+++ b/src/components/LanguageSelector.jsx
@@ -35,18 +35,13 @@ class LanguageSelector extends Component {
   }
 
   render() {
-    let menuLanguages = this.state.newLanguages.slice();
-    const existingLanguages = this.props.translations.map((translation) => {
-      const [languageOption] = languages.filter(option => option.value === translation.language);
-      menuLanguages = menuLanguages.filter(option => option !== languageOption);
-      return languageOption;
-    });
+    const menuLanguages = this.state.newLanguages.filter(option => this.props.languages.indexOf(option) === -1);
 
     return (
       <div>
         <h3>Pick a language</h3>
         <ul className="language-selector">
-          {existingLanguages.filter(Boolean).map((option) => {
+          {this.props.languages.filter(Boolean).map((option) => {
             const checked = this.props.value ? option.value === this.props.value.value : false;
             return (
               <li key={option.value}>
@@ -80,7 +75,7 @@ class LanguageSelector extends Component {
 
 LanguageSelector.propTypes = {
   onChange: PropTypes.func,
-  translations: PropTypes.arrayOf(PropTypes.object),
+  languages: PropTypes.arrayOf(PropTypes.object),
   value: PropTypes.shape({
     label: PropTypes.string,
     value: PropTypes.string
@@ -89,7 +84,7 @@ LanguageSelector.propTypes = {
 
 LanguageSelector.defaultProps = {
   onChange: () => null,
-  translations: [],
+  languages: [],
   value: {
     label: '',
     value: ''

--- a/src/components/Resource.jsx
+++ b/src/components/Resource.jsx
@@ -16,7 +16,7 @@ const resources = {
 function Resource(props) {
   const { contents } = props;
   const ResourceViewer = resources[props.params.resource_type];
-  return (<ResourceViewer contents={contents} />);
+  return (contents.translation && <ResourceViewer contents={contents} />);
 }
 
 Resource.propTypes = {

--- a/src/containers/ProjectContentsContainer.jsx
+++ b/src/containers/ProjectContentsContainer.jsx
@@ -49,11 +49,11 @@ class ProjectContentsContainer extends Component {
   }
 
   componentWillReceiveProps(newProps) {
-    const { actions, params } = this.props;
+    const { actions, params, project, language } = newProps;
     if (newProps.language !== this.props.language && newProps.language.value !== newProps.project.primary_language) {
-      const { original, translations } = newProps.resource;
       const type = params.resource_type;
-      actions.selectTranslation(original, translations, type, newProps.language);
+      const id = type ? params.resource_id : params.project_id;
+      actions.fetchTranslations(id, type, project, language);
     }
   }
 

--- a/src/containers/ProjectDashboardContainer.jsx
+++ b/src/containers/ProjectDashboardContainer.jsx
@@ -5,6 +5,7 @@ import { bindActionCreators } from 'redux';
 import LanguageSelector from '../components/LanguageSelector';
 import { fetchProject, setLanguage } from '../ducks/project';
 import { createTranslation } from '../ducks/resource';
+import languages from '../constants/languages';
 
 class ProjectDashboardContainer extends Component {
   constructor() {
@@ -29,11 +30,14 @@ class ProjectDashboardContainer extends Component {
     const project = this.props.project.data;
     const { fieldguides, language, pages, workflows, tutorials } = this.props.project;
     const { translations } = this.props.resource;
+    const projectLanguages = languages.filter(option =>
+      translations.find(translation => (translation.language === option.value))
+    );
 
     return (
       <div>
         <h2>Project Dashboard</h2>
-        <LanguageSelector translations={translations} value={language} onChange={this.onChangeLanguage} />
+        <LanguageSelector languages={projectLanguages} value={language} onChange={this.onChangeLanguage} />
         {project.primary_language &&
           React.cloneElement(
             this.props.children,

--- a/src/ducks/project.js
+++ b/src/ducks/project.js
@@ -117,7 +117,7 @@ function fetchTutorials(project) {
     dispatch({
       type: FETCH_TUTORIALS
     });
-    apiClient.type('tutorials').get({ project_id: project.id })
+    apiClient.type('tutorials').get({ project_id: project.id, language: project.primary_language })
     .then((tutorials) => {
       dispatch({
         type: FETCH_TUTORIALS_SUCCESS,
@@ -132,7 +132,7 @@ function fetchPages(project) {
     dispatch({
       type: FETCH_PAGES
     });
-    project.get('pages')
+    project.get('pages', { language: project.primary_language })
     .then((pages) => {
       dispatch({
         type: FETCH_PAGES_SUCCESS,
@@ -147,7 +147,7 @@ function fetchFieldGuides(project) {
     dispatch({
       type: FETCH_FIELDGUIDES
     });
-    apiClient.type('field_guides').get({ project_id: project.id })
+    apiClient.type('field_guides').get({ project_id: project.id, language: project.primary_language })
     .then((fieldguides) => {
       dispatch({
         type: FETCH_FIELDGUIDES_SUCCESS,

--- a/src/ducks/project.js
+++ b/src/ducks/project.js
@@ -17,12 +17,14 @@ export const FETCH_FIELDGUIDES = 'FETCH_FIELDGUIDES';
 export const FETCH_FIELDGUIDES_SUCCESS = 'FETCH_FIELDGUIDES_SUCCESS';
 export const FETCH_FIELDGUIDES_ERROR = 'FETCH_FIELDGUIDES_ERROR';
 export const SET_LANGUAGE = 'SET_LANGUAGE';
+export const FETCH_LANGUAGES_SUCCESS = 'FETCH_LANGUAGES_SUCCESS';
 
 // Reducer
 const initialState = {
   data: {},
   fieldguides: [],
   language: null,
+  languageCodes: [],
   pages: [],
   tutorials: [],
   workflows: [],
@@ -35,6 +37,7 @@ function projectReducer(state = initialState, action) {
     case FETCH_PROJECT:
       return Object.assign({}, initialState, { loading: true });
     case FETCH_PROJECT_SUCCESS:
+    case FETCH_LANGUAGES_SUCCESS:
       return Object.assign({}, state, action.payload);
     case FETCH_PROJECT_ERROR:
       return Object.assign({}, state, { error: action.payload, loading: false });
@@ -65,6 +68,22 @@ function setLanguage(language) {
     dispatch({
       type: SET_LANGUAGE,
       language
+    });
+  };
+}
+
+function fetchLanguages(project_id) {
+  return (dispatch) => {
+    apiClient
+    .type('project_contents')
+    .get({ project_id })
+    .then((resources) => {
+      dispatch({
+        type: FETCH_LANGUAGES_SUCCESS,
+        payload: {
+          languageCodes: resources.map(resource => resource.language)
+        }
+      });
     });
   };
 }
@@ -162,5 +181,6 @@ export default projectReducer;
 
 export {
   fetchProject,
-  setLanguage
+  setLanguage,
+  fetchLanguages
 };


### PR DESCRIPTION
Adds language params to the API queries for field guides, tutorials and pages.

This hacks the existing FETCH_TRANSLATIONS action  so that it falls back to requesting resources by language if no translations are returned by the original GET request (which does work for project and workflow contents.) It seems to work, but I'm not a big fan of the nested if blocks that it uses in the action. I think the resulting logic is pretty hard to follow.