### PR TITLE
Use the translations API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4539,14 +4539,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -4555,6 +4547,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -6200,9 +6200,9 @@
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
     },
     "json-api-client": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-3.2.1.tgz",
-      "integrity": "sha1-VZ1BDu37+RUboxHYLeDtbHkqkDs=",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-3.3.0.tgz",
+      "integrity": "sha1-MkCqXTaMXoZLQlenvRnYQixBVLk=",
       "requires": {
         "normalizeurl": "0.1.3",
         "superagent": "1.8.5"
@@ -7675,11 +7675,11 @@
       "dev": true
     },
     "panoptes-client": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-2.7.2.tgz",
-      "integrity": "sha1-xYWVYtNgVCaKoxHihVqhZ3EU+oI=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-2.8.0.tgz",
+      "integrity": "sha1-LJG6Qw2itjeCXQn2+YO878P6J5o=",
       "requires": {
-        "json-api-client": "3.2.1",
+        "json-api-client": "3.3.0",
         "local-storage": "1.4.2",
         "sugar-client": "1.0.1"
       }
@@ -10118,11 +10118,6 @@
       "resolved": "https://registry.npmjs.org/string/-/string-3.3.3.tgz",
       "integrity": "sha1-XqIRzZLSKOGEKUmQpsyXs2anfLA="
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -10132,6 +10127,11 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "strip-ansi": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "history": "^4.6.1",
     "markdownz": "^7.2.1",
-    "panoptes-client": "^2.5.2",
+    "panoptes-client": "^2.8.0",
     "prop-types": "^15.5.10",
     "pui-react-buttons": "^8.3.1",
     "pui-react-iconography": "^8.3.1",

--- a/src/components/ProjectContents.jsx
+++ b/src/components/ProjectContents.jsx
@@ -4,37 +4,37 @@ import TranslationField from './TranslationField';
 
 function ProjectContents(props) {
   const { contents } = props;
-  const original = contents.original || {};
-  const translation = contents.translation || {};
+  const original = contents.original || { strings: {} };
+  const translation = contents.translation || { strings: {} };
   return (
     <div>
       <h2>Project</h2>
       <TranslationField
         translationKey="title"
-        original={original.title}
-        translation={translation.title}
+        original={original.strings.title}
+        translation={translation.strings.title}
       >
         Title
       </TranslationField>
       <TranslationField
         translationKey="description"
-        original={original.description}
-        translation={translation.description}
+        original={original.strings.description}
+        translation={translation.strings.description}
       >
         Description
       </TranslationField>
       <TranslationField
         isMarkdown={true}
         translationKey="introduction"
-        original={original.introduction}
-        translation={translation.introduction}
+        original={original.strings.introduction}
+        translation={translation.strings.introduction}
       >
         Introduction
       </TranslationField>
       <TranslationField
         translationKey="researcher_quote"
-        original={original.researcher_quote}
-        translation={translation.researcher_quote}
+        original={original.strings.researcher_quote}
+        translation={translation.strings.researcher_quote}
       >
         Researcher quote
       </TranslationField>

--- a/src/components/ProjectDashboard.jsx
+++ b/src/components/ProjectDashboard.jsx
@@ -46,7 +46,7 @@ function ProjectDashboard(props) {
             {workflows.map(workflow =>
               (
                 <li key={workflow.id}>
-                  <Link to={`/project/${project.id}/workflows/${workflow.id}`}>{workflow.display_name}</Link>
+                  <Link to={`/project/${project.id}/workflow/${workflow.id}`}>{workflow.display_name}</Link>
                 </li>
               )
             )}

--- a/src/components/ProjectDashboard.jsx
+++ b/src/components/ProjectDashboard.jsx
@@ -6,25 +6,13 @@ import ProjectContents from './ProjectContents';
 
 function TutorialLink(props) {
   const { tutorial, project } = props;
-  switch (tutorial.kind) {
-    case 'mini-course':
-      return (
-        <Link
-          to={`/project/${project.id}/mini_courses/${tutorial.links.workflows[0]}`}
-        >
-          {tutorial.id}: {tutorial.display_name}
-        </Link>
-      );
-    case 'tutorial':
-    default:
-      return (
-        <Link
-          to={`/project/${project.id}/tutorials/${tutorial.links.workflows[0]}`}
-        >
-          {tutorial.id}: {tutorial.display_name}
-        </Link>
-      );
-  }
+  return (
+    <Link
+      to={`/project/${project.id}/tutorial/${tutorial.id}`}
+    >
+      {tutorial.id}: {tutorial.display_name}
+    </Link>
+  );
 }
 
 TutorialLink.propTypes = {
@@ -71,7 +59,7 @@ function ProjectDashboard(props) {
                 (
                   <li key={fieldguide.id}>
                     <Link
-                      to={`/project/${project.id}/field_guides/${fieldguide.id}`}
+                      to={`/project/${project.id}/field_guide/${fieldguide.id}`}
                     >
                       {fieldguide.id}: {fieldguide.display_name}
                     </Link>
@@ -87,7 +75,7 @@ function ProjectDashboard(props) {
                 (
                   <li key={page.id}>
                     <Link
-                      to={`/project/${project.id}/project_pages/${page.url_key}`}
+                      to={`/project/${project.id}/project_page/${page.id}`}
                     >
                       {page.id}: {page.title}
                     </Link>

--- a/src/components/Resource.jsx
+++ b/src/components/Resource.jsx
@@ -10,7 +10,7 @@ const resources = {
   mini_courses: Tutorial,
   project_pages: ProjectPage,
   tutorials: Tutorial,
-  workflows: WorkflowContents
+  workflow: WorkflowContents
 };
 
 function Resource(props) {

--- a/src/components/Resource.jsx
+++ b/src/components/Resource.jsx
@@ -6,10 +6,10 @@ import Tutorial from './Tutorial';
 import WorkflowContents from './WorkflowContents';
 
 const resources = {
-  field_guides: FieldGuide,
-  mini_courses: Tutorial,
-  project_pages: ProjectPage,
-  tutorials: Tutorial,
+  field_guide: FieldGuide,
+  mini_course: Tutorial,
+  project_page: ProjectPage,
+  tutorial: Tutorial,
   workflow: WorkflowContents
 };
 

--- a/src/components/WorkflowContents.jsx
+++ b/src/components/WorkflowContents.jsx
@@ -6,7 +6,7 @@ function WorkflowContents(props) {
   const { contents } = props;
   const original = contents.original || { strings: {} };
   const translation = contents.translation || { strings: {} };
-  const keys = original.strings ? Object.keys(original.strings) : [];
+  const keys = original.strings.tasks ? Object.keys(original.strings.tasks) : [];
   return (
     <div>
       <h2>Workflow Contents</h2>

--- a/src/containers/ProjectContentsContainer.jsx
+++ b/src/containers/ProjectContentsContainer.jsx
@@ -77,11 +77,11 @@ class ProjectContentsContainer extends Component {
         let fieldText;
         let translationText;
         if (subfield && subfield.length) {
-          fieldText = original[field][subfield];
-          translationText = translation[field][subfield];
+          fieldText = original.strings[field][subfield];
+          translationText = translation.strings[field][subfield];
         } else {
-          fieldText = ProjectContentsContainer.getTextFromPath(original, field);
-          translationText = ProjectContentsContainer.getTextFromPath(translation, field);
+          fieldText = ProjectContentsContainer.getTextFromPath(original.strings, field);
+          translationText = ProjectContentsContainer.getTextFromPath(translation.strings, field);
         }
         this.setState({
           field,

--- a/src/containers/ProjectContentsContainer.jsx
+++ b/src/containers/ProjectContentsContainer.jsx
@@ -49,11 +49,11 @@ class ProjectContentsContainer extends Component {
   }
 
   componentWillReceiveProps(newProps) {
-    const { actions, params, project, language } = newProps;
+    const { actions, params, resource, language } = newProps;
     if (newProps.language !== this.props.language && newProps.language.value !== newProps.project.primary_language) {
       const type = params.resource_type;
-      const id = type ? params.resource_id : params.project_id;
-      actions.fetchTranslations(id, type, project, language);
+      const { original, translations } = resource;
+      actions.selectTranslation(original, translations, type, language);
     }
   }
 

--- a/src/containers/ProjectDashboardContainer.jsx
+++ b/src/containers/ProjectDashboardContainer.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import LanguageSelector from '../components/LanguageSelector';
-import { fetchProject, setLanguage, fetchLanguages } from '../ducks/project';
+import { fetchProject, addLanguage, setLanguage, fetchLanguages } from '../ducks/project';
 import { createTranslation } from '../ducks/resource';
 import languages from '../constants/languages';
 
@@ -24,6 +24,11 @@ class ProjectDashboardContainer extends Component {
 
   onChangeLanguage(option) {
     const { actions } = this.props;
+    const { languageCodes } = this.props.project;
+    if (languageCodes.indexOf(option.value) === -1) {
+      languageCodes.push(option.value);
+      actions.addLanguage(languageCodes);
+    }
     actions.setLanguage(option);
   }
 
@@ -57,6 +62,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
   actions: {
     fetchProject: bindActionCreators(fetchProject, dispatch),
+    addLanguage: bindActionCreators(addLanguage, dispatch),
     setLanguage: bindActionCreators(setLanguage, dispatch),
     createTranslation: bindActionCreators(createTranslation, dispatch),
     fetchLanguages: bindActionCreators(fetchLanguages, dispatch)

--- a/src/ducks/project.js
+++ b/src/ducks/project.js
@@ -16,6 +16,7 @@ export const FETCH_PAGES_ERROR = 'FETCH_PAGES_ERROR';
 export const FETCH_FIELDGUIDES = 'FETCH_FIELDGUIDES';
 export const FETCH_FIELDGUIDES_SUCCESS = 'FETCH_FIELDGUIDES_SUCCESS';
 export const FETCH_FIELDGUIDES_ERROR = 'FETCH_FIELDGUIDES_ERROR';
+export const ADD_LANGUAGE = 'ADD_LANGUAGE';
 export const SET_LANGUAGE = 'SET_LANGUAGE';
 export const FETCH_LANGUAGES_SUCCESS = 'FETCH_LANGUAGES_SUCCESS';
 
@@ -57,12 +58,20 @@ function projectReducer(state = initialState, action) {
       return Object.assign({}, state, { fieldguides: action.payload, loading: false });
     case SET_LANGUAGE:
       return Object.assign({}, state, { language: action.language });
+    case ADD_LANGUAGE:
+      return Object.assign({}, state, { languageCodes: action.languageCodes });
     default:
       return state;
   }
 }
 
 // Action Creators
+function addLanguage(languageCodes) {
+  return {
+    type: ADD_LANGUAGE,
+    languageCodes
+  };
+}
 function setLanguage(language) {
   return {
     type: SET_LANGUAGE,
@@ -73,8 +82,11 @@ function setLanguage(language) {
 function fetchLanguages(project_id) {
   return (dispatch) => {
     apiClient
-    .type('project_contents')
-    .get({ project_id })
+    .type('translations')
+    .get({ 
+      translated_type: 'Project',
+      translated_id: project_id 
+    })
     .then((resources) => {
       dispatch({
         type: FETCH_LANGUAGES_SUCCESS,
@@ -179,6 +191,7 @@ export default projectReducer;
 
 export {
   fetchProject,
+  addLanguage,
   setLanguage,
   fetchLanguages
 };

--- a/src/ducks/project.js
+++ b/src/ducks/project.js
@@ -64,11 +64,9 @@ function projectReducer(state = initialState, action) {
 
 // Action Creators
 function setLanguage(language) {
-  return (dispatch) => {
-    dispatch({
-      type: SET_LANGUAGE,
-      language
-    });
+  return {
+    type: SET_LANGUAGE,
+    language
   };
 }
 

--- a/src/ducks/resource.js
+++ b/src/ducks/resource.js
@@ -84,25 +84,21 @@ function createTranslation(original, translations, type, language) {
     type = 'tutorials';
   }
   return (dispatch) => {
-    const newResource = Object.assign({}, original);
-    delete newResource.id;
-    delete newResource.href;
-    delete newResource.created_at;
-    delete newResource.updated_at;
-    delete newResource.links.attached_images;
-    newResource.language = language.value;
+    const newResource = {
+      translated_type: original.translated_type,
+      translated_id: original.translated_id,
+      language: language.value,
+      strings: original.strings
+    }
     dispatch({
       type: CREATE_TRANSLATION,
       newResource,
       original
     });
-    apiClient.type(type)
+    apiClient.type('translations')
     .create(newResource)
     .save()
       .then((translation) => {
-        if (original.links.attached_images) {
-          translation.links.attached_images = original.links.attached_images;
-        }
         translations.push(translation);
         dispatch({
           type: CREATE_TRANSLATION_SUCCESS,

--- a/src/ducks/resource.js
+++ b/src/ducks/resource.js
@@ -131,13 +131,14 @@ function selectTranslation(original, translations, type, language) {
 
 function updateTranslation(translation, field, value) {
   return (dispatch) => {
-    const changes = { [field]: value };
+    const changes = { [`strings.${field}`]: value };
     translation.update(changes);
     dispatch({
       type: UPDATE_TRANSLATION,
       payload: translation
     });
-    translation.save()
+    const { translated_type, translated_id } = translation;
+    translation.save({ translated_type, translated_id })
     .catch(error => console.error('Update translation error:', error));
   };
 }

--- a/src/ducks/resource.js
+++ b/src/ducks/resource.js
@@ -95,9 +95,8 @@ function createTranslation(original, translations, type, language) {
     type = 'tutorials';
   }
   return (dispatch) => {
+    const { translated_type, translated_id } = original;
     const newResource = {
-      translated_type: original.translated_type,
-      translated_id: original.translated_id,
       language: language.value,
       strings: original.strings
     };
@@ -108,7 +107,7 @@ function createTranslation(original, translations, type, language) {
     });
     apiClient.type('translations')
     .create(newResource)
-    .save()
+    .save({ translated_type, translated_id })
       .then((translation) => {
         translations.push(translation);
         dispatch({

--- a/src/ducks/resource.js
+++ b/src/ducks/resource.js
@@ -4,11 +4,11 @@ import apiClient from 'panoptes-client/lib/api-client';
 export const RESET_TRANSLATIONS = 'RESET_TRANSLATIONS';
 export const FETCH_TRANSLATIONS = 'FETCH_TRANSLATIONS';
 export const FETCH_TRANSLATIONS_SUCCESS = 'FETCH_TRANSLATIONS_SUCCESS';
-export const FETCH_TRANSLATIONS_ERROR = 'FETCH_TRANSLATIONS_ERROR';
 export const CREATE_TRANSLATION = 'CREATE_TRANSLATION';
 export const CREATE_TRANSLATION_SUCCESS = 'CREATE_TRANSLATION_SUCCESS';
 export const SELECT_TRANSLATION = 'SELECT_TRANSLATION';
 export const UPDATE_TRANSLATION = 'UPDATE_TRANSLATION';
+export const TRANSLATIONS_ERROR = 'TRANSLATIONS_ERROR';
 
 // Helpers
 function filterResources(resources, primary_language) {
@@ -36,18 +36,26 @@ const resourceReducer = (state = initialState, action) => {
     case FETCH_TRANSLATIONS_SUCCESS:
     case CREATE_TRANSLATION_SUCCESS:
       return Object.assign({}, state, action.payload);
-    case FETCH_TRANSLATIONS_ERROR:
-      return Object.assign({}, state, { error: action.payload, loading: false });
     case SELECT_TRANSLATION:
       return Object.assign({}, state, action.payload);
     case UPDATE_TRANSLATION:
       return Object.assign({}, state, { translation: action.payload });
+    case TRANSLATIONS_ERROR:
+      return Object.assign({}, state, { error: action.payload, loading: false });
     default:
       return state;
   }
 };
 
 // Action Creators
+function handleError(error) {
+  console.warn(error);
+  return {
+    type: TRANSLATIONS_ERROR,
+    payload: error
+  };
+}
+
 function resetTranslations() {
   return (dispatch) => {
     dispatch({
@@ -74,6 +82,9 @@ function fetchTranslations(translated_id, type, project, language) {
         type: FETCH_TRANSLATIONS_SUCCESS,
         payload: { original, translations, loading: false }
       });
+    })
+    .catch((error) => {
+      dispatch(handleError(error));
     });
   };
 }
@@ -89,7 +100,7 @@ function createTranslation(original, translations, type, language) {
       translated_id: original.translated_id,
       language: language.value,
       strings: original.strings
-    }
+    };
     dispatch({
       type: CREATE_TRANSLATION,
       newResource,
@@ -105,7 +116,9 @@ function createTranslation(original, translations, type, language) {
           payload: { translation, translations, loading: false }
         });
       })
-      .catch(error => console.error(error));
+      .catch((error) => {
+        dispatch(handleError(error));
+      });
   };
 }
 
@@ -135,7 +148,9 @@ function updateTranslation(translation, field, value) {
     });
     const { translated_type, translated_id } = translation;
     translation.save({ translated_type, translated_id })
-    .catch(error => console.error('Update translation error:', error));
+    .catch((error) => {
+      dispatch(handleError(error));
+    });
   };
 }
 // Exports


### PR DESCRIPTION
Deletes a whole bunch of code which, I think, was only there to deal with the various different types of translated resource that existed in Panoptes. Instead, all resources are now requested from the API described in zooniverse/Panoptes#2435.

At the moment, `translation.save()` and `apiClient.type('translations').create(translation).save()` both die with 404 errors from the Panoptes API.