### PR TITLE
Fix the editor for workflow tasks

### DIFF
--- a/src/components/WorkflowContents.jsx
+++ b/src/components/WorkflowContents.jsx
@@ -15,10 +15,10 @@ function WorkflowContents(props) {
         (
           <TranslationField
             key={key}
-            translationKey="strings"
+            translationKey="tasks"
             translationSubkey={key}
-            original={original.strings[key]}
-            translation={translation.strings[key]}
+            original={original.strings.tasks[key]}
+            translation={translation.strings.tasks[key]}
           >
             {key}
           </TranslationField>

--- a/src/containers/ProjectContentsContainer.jsx
+++ b/src/containers/ProjectContentsContainer.jsx
@@ -103,7 +103,7 @@ class ProjectContentsContainer extends Component {
     const { actions, resource } = this.props;
     const translation = resource.translation;
     if (subfield && subfield.length) {
-      const changes = translation[field];
+      const changes = translation.strings[field];
       changes[subfield] = translationText;
       actions.updateTranslation(translation, field, changes);
     } else {


### PR DESCRIPTION
Fields with subfields were throwing errors in the translations editor, or not displaying at all.

This should fix them, so that you can edit translations for workflow tasks.