### PR TITLE
Update editor layout

### DIFF
--- a/src/components/TranslationField.jsx
+++ b/src/components/TranslationField.jsx
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import { Markdown } from 'markdownz';
 import FormEdit from 'grommet/components/icons/base/FormEdit';
 import Heading from 'grommet/components/Heading';
+import Box from 'grommet/components/Box';
 import Button from 'grommet/components/Button';
+import Columns from 'grommet/components/Columns';
 import TranslationEditor from './TranslationEditor';
 
 class TranslationField extends React.Component {
@@ -38,23 +40,40 @@ class TranslationField extends React.Component {
     const translationFormatted = isMarkdown ? <Markdown>{translation}</Markdown> : <p>{translation}</p>;
 
     return (
-      <div className="field-editor">
-        <Heading
-          tag="h3"
+      <Box className="field-editor">
+        <Box
+          basis="full"
+          direction="row"
         >
-          {children}
-        </Heading>
-        { originalFormatted }
-        <div lang={languageCode}>
-          { translationFormatted }
-        </div>
-        {(original.length > 0) &&
-          <Button
-            icon={<FormEdit size="small" />}
-            label="Translate"
-            onClick={language ? this.edit.bind(this) : undefined}
-          />
-        }
+          <Box
+            basis="3/4"
+          >
+            <Heading
+              basis="3/4"
+              tag="h3"
+            >
+              {children}
+            </Heading>
+          </Box>
+          <Box>
+            {(original.length > 0) &&
+              <Button
+                fill={false}
+                icon={<FormEdit size="small" />}
+                label="Translate"
+                onClick={language ? this.edit.bind(this) : undefined}
+              />
+            }
+          </Box>
+        </Box>
+        <Columns>
+          <Box direction="row">
+            { originalFormatted }
+          </Box>
+          <Box direction="row" lang={languageCode}>
+            { translationFormatted }
+          </Box>
+        </Columns>
         {editing &&
           <TranslationEditor
             isMarkdown={isMarkdown}
@@ -66,7 +85,7 @@ class TranslationField extends React.Component {
             translationKey={translationKey}
           />
         }
-      </div>
+      </Box>
     );
   }
 }

--- a/src/styles/components/translation-field.styl
+++ b/src/styles/components/translation-field.styl
@@ -1,14 +1,11 @@
 .field-editor
-  display: flex
   font-size: 1em
   border-bottom: 1px solid black
   padding-top: 1em
   
   h3
-    flex: 1
     font-size: 1em
     font-weight: bold
-    position: relative
     vertical-align: middle
     
   .grommetux-button
@@ -16,7 +13,3 @@
     font-size: 0.9em
     padding: 0.1em
     vertical-align: middle
-  
-  > p
-  > div
-    flex: 2


### PR DESCRIPTION
Split the view into two rows, with the name of the translation key displayed above both the original text and the translation.

Fixes #95 

![Screenshot of the survey workflow editor, showing the new layout with keys displayed above the translations.](https://user-images.githubusercontent.com/59547/42631056-f2368886-85d0-11e8-9efd-8c042a1092ce.png)
