### PR TITLE
Inline editing

### DIFF
--- a/src/components/TranslationEditor.jsx
+++ b/src/components/TranslationEditor.jsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import Box from 'grommet/components/Box';
 import Button from 'grommet/components/Button';
-import Layer from 'grommet/components/Layer';
 import { Markdown, MarkdownEditor } from 'markdownz';
 import * as contentsActions from '../ducks/resource';
 
@@ -42,53 +41,62 @@ class TranslationEditor extends React.Component {
     const { isMarkdown, language, onClose, original, translationKey } = this.props;
     const { translationText } = this.state;
     return (
-      <Layer onClose={onClose} closer={true}>
+      <Box
+        basis="full"
+        className="modal-body"
+        direction="row"
+      >
         <Box
-          basis="full"
-          className="modal-body"
-          direction="row"
+          basis="1/2"
+          className="original"
         >
+          {isMarkdown ?
+            <Markdown>
+              {original}
+            </Markdown> :
+            <p>
+              {original}
+            </p>
+          }
+        </Box>
+        <Box
+          basis="1/2"
+          className="translation"
+          lang={language.value}
+        >
+          {isMarkdown ?
+            <MarkdownEditor
+              autoFocus
+              name={translationKey}
+              onChange={this.onChange.bind(this)}
+              previewing={false}
+              value={translationText}
+            /> :
+            <textarea
+              autoFocus
+              onChange={this.onChange.bind(this)}
+              cols={35}
+              rows={4}
+              value={translationText}
+            />
+          }
           <Box
-            basis="1/2"
-            className="original"
+            basis="full"
+            direction="row"
+            justify="end"
           >
-            {isMarkdown ?
-              <Markdown>
-                {original}
-              </Markdown> :
-              <p>
-                {original}
-              </p>
-            }
-          </Box>
-          <Box
-            basis="1/2"
-            className="translation"
-            lang={language.value}
-          >
-            {isMarkdown ?
-              <MarkdownEditor
-                autoFocus
-                name={translationKey}
-                onChange={this.onChange.bind(this)}
-                previewing={false}
-                value={translationText}
-              /> :
-              <textarea
-                autoFocus
-                onChange={this.onChange.bind(this)}
-                cols={35}
-                rows={4}
-                value={translationText}
-              />
-            }
+            <Button
+              label="Cancel"
+              onClick={onClose}
+              secondary={true}
+            />
             <Button
               label="Save"
               onClick={this.save.bind(this)}
             />
           </Box>
         </Box>
-      </Layer>
+      </Box>
     );
   }
 }

--- a/src/components/TranslationField.jsx
+++ b/src/components/TranslationField.jsx
@@ -55,7 +55,7 @@ class TranslationField extends React.Component {
             </Heading>
           </Box>
           <Box>
-            {(original.length > 0) &&
+            {(!editing && original.length > 0) &&
               <Button
                 fill={false}
                 icon={<FormEdit size="small" />}
@@ -65,23 +65,7 @@ class TranslationField extends React.Component {
             }
           </Box>
         </Box>
-        <Box
-          basis="full"
-          direction="row"
-        >
-          <Box
-            basis="1/2"
-          >
-            { originalFormatted }
-          </Box>
-          <Box
-            basis="1/2"
-            lang={languageCode}
-          >
-            { translationFormatted }
-          </Box>
-        </Box>
-        {editing &&
+        {editing ?
           <TranslationEditor
             isMarkdown={isMarkdown}
             language={language}
@@ -90,7 +74,23 @@ class TranslationField extends React.Component {
             original={original}
             translation={translation}
             translationKey={translationKey}
-          />
+          /> :
+          <Box
+            basis="full"
+            direction="row"
+          >
+            <Box
+              basis="1/2"
+            >
+              { originalFormatted }
+            </Box>
+            <Box
+              basis="1/2"
+              lang={languageCode}
+            >
+              { translationFormatted }
+            </Box>
+          </Box>
         }
       </Box>
     );


### PR DESCRIPTION
Remove the modal wrapper on the translations editor.
Show the translations editor inline, in place of the text view, when editing.

Closes #93