### PR TITLE
Remove bitHound score from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![bitHound Score](https://www.bithound.io/github/Granze/react-starterify/badges/score.svg)](https://www.bithound.io/github/zooniverse/zoo-react-starterify/master)
-
 # Pandora
 
 _It unleashes translations on Panoptes._


### PR DESCRIPTION
## PR Overview
This PR removes the bitHound score from the Readme page, because [bitHound](http://bithound.io/) has shut down. 