### PR TITLE
Security update: markdown components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8396,9 +8396,9 @@
       "dev": true
     },
     "markdown-it": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.1.tgz",
-      "integrity": "sha512-CzzqSSNkFRUf9vlWvhK1awpJreMRqdCrBvZ8DIoDWTOkESMIF741UPAhuAmbyWmdiFPA6WARNhnu2M6Nrhwa+A==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
+      "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
       "requires": {
         "argparse": "^1.0.7",
         "entities": "~1.1.1",
@@ -8408,12 +8408,9 @@
       }
     },
     "markdown-it-anchor": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-2.5.1.tgz",
-      "integrity": "sha1-h+O7K1rZWv8m46Bdy4T/TPJV0PM=",
-      "requires": {
-        "string": "^3.0.1"
-      }
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.0.2.tgz",
+      "integrity": "sha512-AFM/woBI8QDJMS/9+MmsBMT5/AR+ImfOsunQZTZhzcTmna3rIzAzbOh5E0l6mlFM/i9666BpUtkqQ9bS7WApCg=="
     },
     "markdown-it-container": {
       "version": "2.0.0",
@@ -8478,12 +8475,12 @@
       }
     },
     "markdownz": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.6.1.tgz",
-      "integrity": "sha512-gPwL8m7Nt8EMzxGVIQwvWMoTSSt48KSkw092ppdCSeEjQsi7dTFlBWwDdFPDtCUc/CdmFl7Uie1mUtj8c1hfAQ==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.6.2.tgz",
+      "integrity": "sha512-//iypNMGKI1t+EUOV+1XGH8w667K/P3osBPxqEQmSMSnWY5W+vzdG7DJjY/5dfHuwsCkb8N3g3MYU+H94cBmrQ==",
       "requires": {
         "markdown-it": "~8.4.1",
-        "markdown-it-anchor": "~2.5.0",
+        "markdown-it-anchor": "~5.0.2",
         "markdown-it-container": "~2.0.0",
         "markdown-it-emoji": "~1.2.0",
         "markdown-it-footnote": "~3.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "grommet": "^1.11.0",
     "history": "^4.6.1",
-    "markdownz": "^7.6.1",
+    "markdownz": "^7.6.2",
     "panoptes-client": "^2.10.0",
     "prop-types": "^15.5.10",
     "react": "^15.5",

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -52,7 +52,7 @@ module.exports = {
   module: {
     rules: [{
       test: /\.jsx?$/,
-      exclude: /node_modules/,
+      exclude: /node_modules\/(?!(markdown-it-anchor)\/).*/, // markdown-it-anchor is written in ES6 and isn't properly compiled
       use: 'babel-loader',
     }, {
       test: /\.css$/,


### PR DESCRIPTION
~This breaks the webpack build, because of ES6 syntax in the latest `markdown-it-anchor`.~