### PR TITLE
Visually clarify language selector button state

### DIFF
--- a/src/components/LanguageSelector.jsx
+++ b/src/components/LanguageSelector.jsx
@@ -53,7 +53,15 @@ class LanguageSelector extends Component {
                     value={option.value}
                     onChange={this.onLanguageChange}
                   />
-                  <span className="grommetux-button">{option.label}</span>
+                  <span
+                    className={
+                      checked ?
+                      "grommetux-button grommetux-button--primary" :
+                      "grommetux-button"
+                    }
+                  >
+                    {option.label}
+                  </span>
                 </label>
               </li>
             );

--- a/src/styles/components/language-selector.styl
+++ b/src/styles/components/language-selector.styl
@@ -13,15 +13,9 @@
     
       & + span
         border-radius: .2em
-        color: grey
         font-size: .8em
         padding: .2em .5em
         margin: .2em
-        opacity: 0.3
-    
-      &:checked + span
-        color: black
-        opacity: 1
 
 .grommetux-select
   display: inline-block


### PR DESCRIPTION
Use the Grommet primary button style to indicate selected state.
Remove disabled styling (low opacity) from buttons that were not disabled.

Closes #104.