### PR TITLE
Hide project details on first load

### DIFF
--- a/src/components/ProjectDashboard.jsx
+++ b/src/components/ProjectDashboard.jsx
@@ -25,7 +25,7 @@ function ProjectDashboard(props) {
   return (
     <div>
       <ProjectContentsContainer {...props}>
-        <ProjectContents />
+        {language ? <ProjectContents /> : <p>Select a language to start.</p>}
       </ProjectContentsContainer>
       { language &&
         <div>


### PR DESCRIPTION
Display 'Select a language to start.' until a language is selected.