### PR TITLE
New translations default to blank strings

### DIFF
--- a/src/components/TranslationEditor.jsx
+++ b/src/components/TranslationEditor.jsx
@@ -10,16 +10,14 @@ import * as contentsActions from '../ducks/resource';
 class TranslationEditor extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      translationText: props.translation
-    };
+    const translationText = props.translation ? props.translation : props.original;
+    this.state = { translationText };
   }
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.translation !== this.props.translation) {
-      this.setState({
-        translationText: nextProps.translation
-      });
+      const translationText = nextProps.translation ? nextProps.translation : nextProps.original;
+      this.setState({ translationText });
     }
   }
 

--- a/src/ducks/resource.js
+++ b/src/ducks/resource.js
@@ -98,7 +98,7 @@ function createTranslation(original, translations, type, language) {
     const { translated_type, translated_id } = original;
     const newResource = {
       language: language.value,
-      strings: original.strings
+      strings: {}
     };
     dispatch({
       type: CREATE_TRANSLATION,
@@ -142,7 +142,7 @@ function updateTranslation(original, translation, updatedField, value) {
   return (dispatch) => {
     const strings = {};
     Object.keys(original.strings).forEach((field) => {
-      strings[field] = translation.strings[field] || original.strings[field];
+      strings[field] = translation.strings[field] || '';
     });
     strings[updatedField] = value;
     const changes = { strings };


### PR DESCRIPTION
Create new translation strings as empty objects.
Don't automatically copy the original to the translation on update.
Use the original text as a starting point in the translation editor if the translation is empty.

Closes #92.