### PR TITLE
[WIP] Set string_versions to the version of the field on the original

### DIFF
--- a/src/ducks/resource.js
+++ b/src/ducks/resource.js
@@ -108,7 +108,8 @@ function createTranslation(original, translations, type, language) {
     const { translated_type, translated_id } = original;
     const newResource = {
       language: language.value,
-      strings: {}
+      strings: {},
+      string_versions: {}
     };
     dispatch({
       type: CREATE_TRANSLATION,
@@ -151,11 +152,17 @@ function selectTranslation(original, translations, type, language) {
 function updateTranslation(original, translation, updatedField, value) {
   return (dispatch) => {
     const strings = {};
+    const string_versions = {};
+
     Object.keys(original.strings).forEach((field) => {
       strings[field] = translation.strings[field] || '';
+      string_versions[field] = translation.string_versions[field];
     });
+
     strings[updatedField] = value;
-    const changes = { strings };
+    string_versions[updatedField] = original.string_versions[updatedField];
+
+    const changes = { strings, string_versions };
     translation.update(changes);
     dispatch({
       type: UPDATE_TRANSLATION,


### PR DESCRIPTION
https://github.com/zooniverse/Panoptes/pull/2973 will introduce the concept of string versions. This PR updates Pandora to work with these. It sets the version of a edited string to the version of the original.

We'll need one more PR on the backend side to make `string_versions` editable through the API (it'll need to verify that the given versions make sense and actually belong to the resource being translated, and that was going to make the above linked PR too big, so I split that off).

But that does mean we shouldn't merge this yet, because the API isn't actually set up to work for this yet.