### PR TITLE
Flag outdated fields when viewing translations

### DIFF
--- a/src/components/FieldGuide.jsx
+++ b/src/components/FieldGuide.jsx
@@ -7,6 +7,9 @@ function FieldGuide(props) {
   const original = contents.original || { strings: {} };
   const translation = contents.translation || original;
   const fields = Object.keys(original.strings);
+  function isOutdated(field) {
+    return translation.string_versions && translation.string_versions[field] < original.string_versions[field];
+  }
   return (
     <div>
       <h2>Field Guide</h2>
@@ -20,6 +23,7 @@ function FieldGuide(props) {
               language={language}
               original={original.strings[field]}
               translation={translation.strings[field]}
+              isOutdated={isOutdated(field)}
             >
               {field}
             </TranslationField>

--- a/src/components/ProjectContents.jsx
+++ b/src/components/ProjectContents.jsx
@@ -6,6 +6,9 @@ function ProjectContents(props) {
   const { contents, language } = props;
   const original = contents.original || { strings: {} };
   const translation = contents.translation || { strings: {} };
+  function isOutdated(field) {
+    return translation.string_versions && translation.string_versions[field] < original.string_versions[field];
+  }
   return (
     <div>
       <h2>Project</h2>
@@ -14,6 +17,7 @@ function ProjectContents(props) {
         language={language}
         original={original.strings.title}
         translation={translation.strings.title}
+        isOutdated={isOutdated('title')}
       >
         Title
       </TranslationField>
@@ -22,6 +26,7 @@ function ProjectContents(props) {
         language={language}
         original={original.strings.display_name}
         translation={translation.strings.display_name}
+        isOutdated={isOutdated('display_name')}
       >
         Display Name
       </TranslationField>
@@ -30,6 +35,7 @@ function ProjectContents(props) {
         language={language}
         original={original.strings.description}
         translation={translation.strings.description}
+        isOutdated={isOutdated('description')}
       >
         Description
       </TranslationField>
@@ -39,6 +45,7 @@ function ProjectContents(props) {
         language={language}
         original={original.strings.introduction}
         translation={translation.strings.introduction}
+        isOutdated={isOutdated('introduction')}
       >
         Introduction
       </TranslationField>
@@ -47,6 +54,7 @@ function ProjectContents(props) {
         language={language}
         original={original.strings.researcher_quote}
         translation={translation.strings.researcher_quote}
+        isOutdated={isOutdated('researcher_quote')}
       >
         Researcher quote
       </TranslationField>

--- a/src/components/ProjectPage.jsx
+++ b/src/components/ProjectPage.jsx
@@ -6,6 +6,9 @@ function ProjectPage(props) {
   const { contents, language } = props;
   const original = contents.original.strings || {};
   const translation = contents.translation.strings || original;
+  function isOutdated(field) {
+    return translation.string_versions && translation.string_versions[field] < original.string_versions[field];
+  }
   return (
     <div>
       <h2>Project Page</h2>
@@ -15,6 +18,7 @@ function ProjectPage(props) {
         language={language}
         original={original.title}
         translation={translation.title}
+        isOutdated={isOutdated('title')}
       >
         Title
       </TranslationField>
@@ -24,6 +28,7 @@ function ProjectPage(props) {
         language={language}
         original={original.content}
         translation={translation.content}
+        isOutdated={isOutdated('content')}
       >
         Content
       </TranslationField>

--- a/src/components/TranslationField.jsx
+++ b/src/components/TranslationField.jsx
@@ -52,6 +52,7 @@ class TranslationField extends React.Component {
               tag="h3"
             >
               {children}
+              {this.props.isOutdated ? ' (Out of date)' : null}
             </Heading>
           </Box>
           <Box>
@@ -77,6 +78,7 @@ class TranslationField extends React.Component {
           /> :
           <Box
             basis="full"
+            className={this.props.isOutdated ? 'outdated' : undefined}
             direction="row"
           >
             <Box
@@ -100,6 +102,7 @@ class TranslationField extends React.Component {
 TranslationField.propTypes = {
   children: PropTypes.node.isRequired,
   isMarkdown: PropTypes.bool,
+  isOutdated: PropTypes.bool,
   language: PropTypes.shape({
     label: PropTypes.string,
     value: PropTypes.string
@@ -111,6 +114,7 @@ TranslationField.propTypes = {
 
 TranslationField.defaultProps = {
   isMarkdown: undefined,
+  isOutdated: false,
   language: {
     label: 'English',
     value: 'en'

--- a/src/components/Tutorial.jsx
+++ b/src/components/Tutorial.jsx
@@ -7,6 +7,9 @@ function Tutorial(props) {
   const original = contents.original || { strings: {} };
   const translation = contents.translation || original;
   const fields = Object.keys(original.strings);
+  function isOutdated(field) {
+    return translation.string_versions && translation.string_versions[field] < original.string_versions[field];
+  }
   return (
     <div>
       <h2>Tutorial</h2>
@@ -19,6 +22,7 @@ function Tutorial(props) {
             language={language}
             original={original.strings[field]}
             translation={translation.strings[field]}
+            isOutdated={isOutdated(field)}
           >
             {field}
           </TranslationField>

--- a/src/components/WorkflowContents.jsx
+++ b/src/components/WorkflowContents.jsx
@@ -7,6 +7,9 @@ function WorkflowContents(props) {
   const original = contents.original || { strings: {} };
   const translation = contents.translation || original;
   const keys = original.strings ? Object.keys(original.strings) : [];
+  function isOutdated(field) {
+    return translation.string_versions && translation.string_versions[field] < original.string_versions[field];
+  }
   return (
     <div>
       <h2>Workflow Contents</h2>
@@ -22,6 +25,7 @@ function WorkflowContents(props) {
             original={original.strings[key]}
             translation={translation.strings[key]}
             isMarkdown={true}
+            isOutdated={isOutdated(key)}
           >
             {key}
           </TranslationField>

--- a/src/styles/components/translation-field.styl
+++ b/src/styles/components/translation-field.styl
@@ -1,3 +1,6 @@
+.outdated
+  background: #f7bbbb
+
 .field-editor
   font-size: 1em
   border-bottom: 1px solid black


### PR DESCRIPTION
Flag up outdated translations by adding '(Out of date)' to the field heading and change the background colour.
![Project translation editor showing an outdated introduction with a light red background.](https://user-images.githubusercontent.com/59547/53499532-73978900-3aa0-11e9-89ab-3319feb273c2.png)
