### PR TITLE
Handle null originals

### DIFF
--- a/src/components/TranslationField.jsx
+++ b/src/components/TranslationField.jsx
@@ -56,7 +56,7 @@ class TranslationField extends React.Component {
             </Heading>
           </Box>
           <Box>
-            {(!editing && original.length > 0) &&
+            {(!editing && original && original.length > 0) &&
               <Button
                 fill={false}
                 icon={<FormEdit size="small" />}


### PR DESCRIPTION
The translation editor could crash if the original string was passed in as null. This adds a check for original && original.length before displaying the Translate button.