### PR TITLE
Add support for organisations

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import OrganisationList from '../containers/OrganisationListContainer';
+import ProjectList from '../containers/ProjectListContainer';
+
+export default function Home(props) {
+  return (
+    <React.Fragment>
+      <OrganisationList />
+      <ProjectList />
+    </React.Fragment>
+  )
+}

--- a/src/components/Organisation.jsx
+++ b/src/components/Organisation.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import TranslationField from './TranslationField';
+
+function Organisation(props) {
+  const { contents, language } = props;
+  const original = contents.original || { strings: {} };
+  const translation = contents.translation || original;
+  const fields = Object.keys(original.strings);
+  function isOutdated(field) {
+    return translation.string_versions && translation.string_versions[field] < original.string_versions[field];
+  }
+  return (
+    <div>
+      <h2>Organisation</h2>
+      {fields.map(field =>
+        (
+          <TranslationField
+            key={field}
+            isMarkdown={true}
+            translationKey={field}
+            language={language}
+            original={original.strings[field]}
+            translation={translation.strings[field]}
+            isOutdated={isOutdated(field)}
+          >
+            {field}
+          </TranslationField>
+        )
+      )}
+    </div>
+  );
+}
+
+Organisation.propTypes = {
+  contents: PropTypes.PropTypes.shape({
+    original: PropTypes.object,
+    translation: PropTypes.object
+  }).isRequired,
+  language: PropTypes.shape({
+    label: PropTypes.string,
+    value: PropTypes.string
+  }).isRequired
+};
+
+export default Organisation;

--- a/src/components/OrganisationDashboard.jsx
+++ b/src/components/OrganisationDashboard.jsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ResourceContainer from '../containers/ResourceContainer';
-import Resource from './Resource';
+import Organisation from './Organisation';
 
 function OrganisationDashboard(props) {
   const { language, organisation } = props;
+  const params = {
+    resource_type: 'organization',
+    resource_id: props.params.organization_id
+  }
   return (
     <div>
       {language ?
-        <ResourceContainer {...props} resource_type='organization'>
-          <Resource resource_type='organization' />
+        <ResourceContainer {...props} params={params}>
+          <Organisation />
         </ResourceContainer> :
         <p>Select a language to start.</p>
       }

--- a/src/components/OrganisationDashboard.jsx
+++ b/src/components/OrganisationDashboard.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ResourceContainer from '../containers/ResourceContainer';
+import Resource from './Resource';
+
+function OrganisationDashboard(props) {
+  const { language, organisation } = props;
+  return (
+    <div>
+      {language ?
+        <ResourceContainer {...props} resource_type='organization'>
+          <Resource resource_type='organization' />
+        </ResourceContainer> :
+        <p>Select a language to start.</p>
+      }
+    </div>
+  );
+}
+
+OrganisationDashboard.propTypes = {
+  language: PropTypes.shape({
+    label: PropTypes.string,
+    value: PropTypes.string
+  }),
+  project: PropTypes.object.isRequired
+};
+
+
+OrganisationDashboard.defaultProps = {
+  language: {
+    label: '',
+    value: ''
+  },
+  project: {}
+};
+
+export default OrganisationDashboard;

--- a/src/components/OrganisationList.jsx
+++ b/src/components/OrganisationList.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router';
+
+function OrganisationListItem(props) {
+  return (
+    <li key={props.organisation.id}>
+      <Link to={`/organization/${props.organisation.id}`} >{props.organisation.display_name}</Link>
+    </li>
+  );
+}
+
+OrganisationListItem.propTypes = {
+  organisation: PropTypes.shape({
+    id: PropTypes.string,
+    display_name: PropTypes.string
+  }).isRequired
+};
+
+function OrganisationList(props) {
+  const { organisations } = props;
+  return (
+    <div>
+      <h2>Your Organisations</h2>
+      <ul>
+        {organisations.data.map(organisation => (
+          <OrganisationListItem key={organisation.id} organisation={organisation} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+OrganisationList.propTypes = {
+  organisations: PropTypes.shape({
+    data: PropTypes.arrayOf(PropTypes.object)
+  }).isRequired
+};
+
+OrganisationList.defaultProps = {
+  organisations: {
+    data: []
+  }
+};
+
+export default OrganisationList;

--- a/src/components/ProjectDashboard.jsx
+++ b/src/components/ProjectDashboard.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
-import ProjectContentsContainer from '../containers/ProjectContentsContainer';
+import ResourceContainer from '../containers/ResourceContainer';
 import ProjectContents from './ProjectContents';
 
 function TutorialLink(props) {
@@ -25,9 +25,9 @@ function ProjectDashboard(props) {
   return (
     <div>
       {language ?
-        <ProjectContentsContainer {...props}>
+        <ResourceContainer {...props}>
           <ProjectContents />
-        </ProjectContentsContainer> :
+        </ResourceContainer> :
         <p>Select a language to start.</p>
       }
       { language &&

--- a/src/components/ProjectDashboard.jsx
+++ b/src/components/ProjectDashboard.jsx
@@ -22,10 +22,14 @@ TutorialLink.propTypes = {
 
 function ProjectDashboard(props) {
   const { fieldguides, language, project, tutorials, workflows } = props;
+  const params = {
+    resource_type: 'project',
+    resource_id: props.params.project_id
+  }
   return (
     <div>
       {language ?
-        <ResourceContainer {...props}>
+        <ResourceContainer {...props} params={params}>
           <ProjectContents />
         </ResourceContainer> :
         <p>Select a language to start.</p>

--- a/src/components/ProjectList.jsx
+++ b/src/components/ProjectList.jsx
@@ -21,7 +21,7 @@ function ProjectList(props) {
   const { projects } = props;
   return (
     <div>
-      <h2>Projects</h2>
+      <h2>Your Projects</h2>
       <ul>
         {projects.data.map(project => <ProjectListItem key={project.id} project={project} />)}
       </ul>

--- a/src/components/Resource.jsx
+++ b/src/components/Resource.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import FieldGuide from './FieldGuide';
+import Organisation from './Organisation';
 import ProjectPage from './ProjectPage';
 import Tutorial from './Tutorial';
 import WorkflowContents from './WorkflowContents';
@@ -8,6 +9,7 @@ import WorkflowContents from './WorkflowContents';
 const resources = {
   field_guide: FieldGuide,
   mini_course: Tutorial,
+  organization: Organisation,
   project_page: ProjectPage,
   tutorial: Tutorial,
   workflow: WorkflowContents

--- a/src/containers/OrganisationDashboardContainer.jsx
+++ b/src/containers/OrganisationDashboardContainer.jsx
@@ -41,10 +41,10 @@ class OrganisationDashboardContainer extends Component {
 
   render() {
     const organisation = this.props.organisation.data;
-    const { language, languageCodes } = this.props.organisation;
+    const { language, languageCodes, primary_language } = this.props.organisation;
     const organisationLanguages = languages
       .filter(option => (languageCodes.indexOf(option.value) > -1))
-      .filter(option => (option.value !== organisation.primary_language));
+      .filter(option => (option.value !== primary_language));
     return (
       <div>
         <h2>
@@ -66,10 +66,10 @@ class OrganisationDashboardContainer extends Component {
             </a>
           </p>
         }
-        {organisation.primary_language &&
+        {primary_language &&
           React.cloneElement(
             this.props.children,
-            { language, organisation }
+            { language, organisation, primary_language }
           )
         }
       </div>
@@ -101,15 +101,12 @@ OrganisationDashboardContainer.propTypes = {
   }),
   organisation: PropTypes.shape({
     data: PropTypes.object,
-    fieldguides: PropTypes.array,
     language: PropTypes.shape({
       label: PropTypes.string,
       value: PropTypes.string
     }),
     languageCodes: PropTypes.arrayOf(PropTypes.string),
-    pages: PropTypes.array,
-    tutorials: PropTypes.array,
-    workflows: PropTypes.array
+    primary_language: PropTypes.string
   }),
   params: PropTypes.shape({
     organisation_id: PropTypes.string
@@ -123,8 +120,7 @@ OrganisationDashboardContainer.defaultProps = {
     data: null,
     language: null,
     languageCodes: [],
-    tutorials: [],
-    workflows: []
+    primary_language: 'en'
   }
 };
 export default connect(

--- a/src/containers/OrganisationDashboardContainer.jsx
+++ b/src/containers/OrganisationDashboardContainer.jsx
@@ -19,9 +19,9 @@ class OrganisationDashboardContainer extends Component {
   }
 
   componentDidMount() {
-    const { actions, params } = this.props;
+    const { actions, adminMode, params } = this.props;
     const { query } = this.props.location;
-    actions.fetchOrganisation(params.organization_id);
+    actions.fetchOrganisation(params.organization_id, adminMode);
     actions.fetchLanguages(params.organization_id);
     if (query.language) {
       const language = languages.filter(option => option.value === query.language)[0];
@@ -78,6 +78,7 @@ class OrganisationDashboardContainer extends Component {
 }
 
 const mapStateToProps = state => ({
+  adminMode: state.login.adminMode,
   language: state.language,
   languages: state.languages,
   organisation: state.organisation,
@@ -95,6 +96,7 @@ const mapDispatchToProps = dispatch => ({
 
 OrganisationDashboardContainer.propTypes = {
   actions: PropTypes.objectOf(PropTypes.func).isRequired,
+  adminMode: PropTypes.bool,
   children: PropTypes.node,
   location: PropTypes.shape({
     query: PropTypes.object
@@ -114,6 +116,7 @@ OrganisationDashboardContainer.propTypes = {
 };
 
 OrganisationDashboardContainer.defaultProps = {
+  adminMode: false,
   children: null,
   location: {},
   organisation: {

--- a/src/containers/OrganisationDashboardContainer.jsx
+++ b/src/containers/OrganisationDashboardContainer.jsx
@@ -1,0 +1,133 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { Link } from 'react-router';
+import LanguageSelector from '../components/LanguageSelector';
+import { fetchOrganisation, addLanguage, setLanguage, fetchLanguages } from '../ducks/organisation';
+import { createTranslation } from '../ducks/resource';
+import languages from '../constants/languages';
+import config from '../constants/config';
+
+class OrganisationDashboardContainer extends Component {
+  constructor() {
+    super();
+    this.onChangeLanguage = this.onChangeLanguage.bind(this);
+    this.state = {
+      searchText: ''
+    };
+  }
+
+  componentDidMount() {
+    const { actions, params } = this.props;
+    const { query } = this.props.location;
+    actions.fetchOrganisation(params.organization_id);
+    actions.fetchLanguages(params.organization_id);
+    if (query.language) {
+      const language = languages.filter(option => option.value === query.language)[0];
+      actions.setLanguage(language);
+    }
+  }
+
+  onChangeLanguage(option) {
+    const { actions } = this.props;
+    const { languageCodes } = this.props.organisation;
+    if (languageCodes.indexOf(option.value) === -1) {
+      languageCodes.push(option.value);
+      actions.addLanguage(languageCodes);
+    }
+    actions.setLanguage(option);
+  }
+
+  render() {
+    const organisation = this.props.organisation.data;
+    const { language, languageCodes } = this.props.organisation;
+    const organisationLanguages = languages
+      .filter(option => (languageCodes.indexOf(option.value) > -1))
+      .filter(option => (option.value !== organisation.primary_language));
+    return (
+      <div>
+        <h2>
+          <Link
+            to={`/organisation/${organisation.id}`}
+          >
+            {organisation.display_name}
+          </Link>
+        </h2>
+        <LanguageSelector languages={organisationLanguages} value={language} onChange={this.onChangeLanguage} />
+        {language &&
+          <p className="preview">
+            <a
+              className="grommetux-button"
+              target="preview"
+              href={`${config.projectHost}/organizations/${organisation.slug}?language=${language.value}`}
+            >
+              Preview your translation
+            </a>
+          </p>
+        }
+        {organisation.primary_language &&
+          React.cloneElement(
+            this.props.children,
+            { language, organisation }
+          )
+        }
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  language: state.language,
+  languages: state.languages,
+  organisation: state.organisation,
+  resource: state.resource
+});
+const mapDispatchToProps = dispatch => ({
+  actions: {
+    fetchOrganisation: bindActionCreators(fetchOrganisation, dispatch),
+    addLanguage: bindActionCreators(addLanguage, dispatch),
+    setLanguage: bindActionCreators(setLanguage, dispatch),
+    createTranslation: bindActionCreators(createTranslation, dispatch),
+    fetchLanguages: bindActionCreators(fetchLanguages, dispatch)
+  }
+});
+
+OrganisationDashboardContainer.propTypes = {
+  actions: PropTypes.objectOf(PropTypes.func).isRequired,
+  children: PropTypes.node,
+  location: PropTypes.shape({
+    query: PropTypes.object
+  }),
+  organisation: PropTypes.shape({
+    data: PropTypes.object,
+    fieldguides: PropTypes.array,
+    language: PropTypes.shape({
+      label: PropTypes.string,
+      value: PropTypes.string
+    }),
+    languageCodes: PropTypes.arrayOf(PropTypes.string),
+    pages: PropTypes.array,
+    tutorials: PropTypes.array,
+    workflows: PropTypes.array
+  }),
+  params: PropTypes.shape({
+    organisation_id: PropTypes.string
+  }).isRequired
+};
+
+OrganisationDashboardContainer.defaultProps = {
+  children: null,
+  location: {},
+  organisation: {
+    data: null,
+    language: null,
+    languageCodes: [],
+    tutorials: [],
+    workflows: []
+  }
+};
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(OrganisationDashboardContainer);

--- a/src/containers/OrganisationListContainer.jsx
+++ b/src/containers/OrganisationListContainer.jsx
@@ -1,0 +1,49 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+import * as organisationsActions from '../ducks/organisations';
+
+import OrganisationList from '../components/OrganisationList';
+
+class OrganisationListContainer extends Component {
+
+  componentDidMount() {
+    const { actions } = this.props;
+    actions.fetchOrganisations();
+  }
+
+  render() {
+    const { organisations } = this.props;
+    return (
+      <OrganisationList organisations={organisations} />
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  organisations: state.organisations
+});
+
+const mapDispatchToProps = dispatch => ({
+  actions: bindActionCreators(organisationsActions, dispatch)
+});
+
+OrganisationListContainer.propTypes = {
+  actions: PropTypes.objectOf(PropTypes.func).isRequired,
+  organisations: PropTypes.shape({
+    data: PropTypes.arrayOf(PropTypes.object)
+  }).isRequired
+};
+
+OrganisationListContainer.defaultProps = {
+  organisations: {
+    data: []
+  }
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(OrganisationListContainer);

--- a/src/containers/ProjectDashboardContainer.jsx
+++ b/src/containers/ProjectDashboardContainer.jsx
@@ -41,10 +41,10 @@ class ProjectDashboardContainer extends Component {
 
   render() {
     const project = this.props.project.data;
-    const { fieldguides, language, languageCodes, pages, workflows, tutorials } = this.props.project;
+    const { fieldguides, language, languageCodes, pages, primary_language, workflows, tutorials } = this.props.project;
     const projectLanguages = languages
       .filter(option => (languageCodes.indexOf(option.value) > -1))
-      .filter(option => (option.value !== project.primary_language));
+      .filter(option => (option.value !== primary_language));
     return (
       <div>
         <h2>
@@ -66,10 +66,10 @@ class ProjectDashboardContainer extends Component {
             </a>
           </p>
         }
-        {project.primary_language &&
+        {primary_language &&
           React.cloneElement(
             this.props.children,
-            { fieldguides, language, pages, project, tutorials, workflows }
+            { fieldguides, language, pages, primary_language, project, tutorials, workflows }
           )
         }
       </div>

--- a/src/containers/ResourceContainer.jsx
+++ b/src/containers/ResourceContainer.jsx
@@ -13,17 +13,16 @@ class ResourceContainer extends Component {
 
   componentDidMount() {
     const { actions, params, primary_language, language } = this.props;
-    const type = params.resource_type;
-    const id = type ? params.resource_id : params.project_id;
-    actions.fetchTranslations(id, type, primary_language, language);
+    const { resource_id, resource_type } = params;
+    actions.fetchTranslations(resource_id, resource_type, primary_language, language);
   }
 
   componentWillReceiveProps(newProps) {
     const { actions, params, resource, language } = newProps;
     if (newProps.language !== this.props.language && newProps.language.value !== newProps.primary_language) {
-      const type = params.resource_type;
+      const { resource_type } = params;
       const { original, translations } = resource;
-      actions.selectTranslation(original, translations, type, language);
+      actions.selectTranslation(original, translations, resource_type, language);
     }
     if (newProps.resource.error) {
       const { message, status, statusText } = newProps.resource.error;
@@ -53,7 +52,6 @@ ResourceContainer.propTypes = {
     value: PropTypes.string
   }),
   params: PropTypes.shape({
-    project_id: PropTypes.string,
     resource_id: PropTypes.string,
     resource_type: PropTypes.string
   }).isRequired,

--- a/src/containers/ResourceContainer.jsx
+++ b/src/containers/ResourceContainer.jsx
@@ -12,15 +12,15 @@ class ResourceContainer extends Component {
   }
 
   componentDidMount() {
-    const { actions, params, project, language } = this.props;
+    const { actions, params, primary_language, language } = this.props;
     const type = params.resource_type;
     const id = type ? params.resource_id : params.project_id;
-    actions.fetchTranslations(id, type, project, language);
+    actions.fetchTranslations(id, type, primary_language, language);
   }
 
   componentWillReceiveProps(newProps) {
     const { actions, params, resource, language } = newProps;
-    if (newProps.language !== this.props.language && newProps.language.value !== newProps.project.primary_language) {
+    if (newProps.language !== this.props.language && newProps.language.value !== newProps.primary_language) {
       const type = params.resource_type;
       const { original, translations } = resource;
       actions.selectTranslation(original, translations, type, language);
@@ -57,17 +57,7 @@ ResourceContainer.propTypes = {
     resource_id: PropTypes.string,
     resource_type: PropTypes.string
   }).isRequired,
-  project: PropTypes.shape({
-    data: PropTypes.object,
-    fieldguides: PropTypes.array,
-    language: PropTypes.shape({
-      label: PropTypes.string,
-      value: PropTypes.string
-    }),
-    pages: PropTypes.array,
-    tutorials: PropTypes.array,
-    workflows: PropTypes.array
-  }).isRequired,
+  primary_language: PropTypes.string,
   resource: PropTypes.object.isRequired
 };
 
@@ -76,7 +66,8 @@ ResourceContainer.defaultProps = {
   language: {
     label: '',
     value: ''
-  }
+  },
+  primary_language: 'en'
 };
 
 export default connect(

--- a/src/containers/ResourceContainer.jsx
+++ b/src/containers/ResourceContainer.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as contentsActions from '../ducks/resource';
 
-class ProjectContentsContainer extends Component {
+class ResourceContainer extends Component {
 
   componentWillMount() {
     const { actions } = this.props;
@@ -33,8 +33,8 @@ class ProjectContentsContainer extends Component {
   }
 
   render() {
-    const { language, project, resource } = this.props;
-    return React.cloneElement(this.props.children, { contents: resource, language, project });
+    const { language, resource } = this.props;
+    return React.cloneElement(this.props.children, { contents: resource, language });
   }
 }
 
@@ -45,7 +45,7 @@ const mapDispatchToProps = dispatch => ({
   actions: bindActionCreators(contentsActions, dispatch)
 });
 
-ProjectContentsContainer.propTypes = {
+ResourceContainer.propTypes = {
   actions: PropTypes.objectOf(PropTypes.func).isRequired,
   children: PropTypes.node,
   language: PropTypes.shape({
@@ -71,7 +71,7 @@ ProjectContentsContainer.propTypes = {
   resource: PropTypes.object.isRequired
 };
 
-ProjectContentsContainer.defaultProps = {
+ResourceContainer.defaultProps = {
   children: null,
   language: {
     label: '',
@@ -82,4 +82,4 @@ ProjectContentsContainer.defaultProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(ProjectContentsContainer);
+)(ResourceContainer);

--- a/src/ducks/organisation.js
+++ b/src/ducks/organisation.js
@@ -70,15 +70,15 @@ function fetchLanguages(organisation_id) {
   };
 }
 
-function fetchOrganisation(id) {
+function fetchOrganisation(id, isAdmin) {
   return (dispatch) => {
     dispatch({
       type: FETCH_ORGANISATION
     });
-    const query = {
-      id,
-      current_user_roles: ALLOWED_ROLES
-    };
+    const query = { id };
+    if (!isAdmin) {
+      query.current_user_roles = ALLOWED_ROLES;
+    }
     apiClient.type('organizations').get(query)
     .then(([organisation]) => {
       dispatch({

--- a/src/ducks/organisation.js
+++ b/src/ducks/organisation.js
@@ -1,0 +1,104 @@
+import apiClient from 'panoptes-client/lib/api-client';
+
+const ALLOWED_ROLES = ['owner', 'collaborator', 'translator'];
+
+// Action Types
+export const FETCH_ORGANISATION = 'FETCH_ORGANISATION';
+export const FETCH_ORGANISATION_SUCCESS = 'FETCH_ORGANISATION_SUCCESS';
+export const FETCH_ORGANISATION_ERROR = 'FETCH_ORGANISATION_ERROR';
+export const ADD_LANGUAGE = 'ADD_LANGUAGE';
+export const SET_LANGUAGE = 'SET_LANGUAGE';
+export const FETCH_LANGUAGES_SUCCESS = 'FETCH_LANGUAGES_SUCCESS';
+
+// Reducer
+const initialState = {
+  data: {},
+  language: null,
+  languageCodes: [],
+  error: false,
+  loading: false
+};
+
+function organisationReducer(state = initialState, action) {
+  switch (action.type) {
+    case FETCH_ORGANISATION:
+      return Object.assign({}, initialState, { loading: true });
+    case FETCH_ORGANISATION_SUCCESS:
+    case FETCH_LANGUAGES_SUCCESS:
+      return Object.assign({}, state, action.payload);
+    case FETCH_ORGANISATION_ERROR:
+      return Object.assign({}, state, { error: action.payload, loading: false });
+    case SET_LANGUAGE:
+      return Object.assign({}, state, { language: action.language });
+    case ADD_LANGUAGE:
+      return Object.assign({}, state, { languageCodes: action.languageCodes });
+    default:
+      return state;
+  }
+}
+
+// Action Creators
+function addLanguage(languageCodes) {
+  return {
+    type: ADD_LANGUAGE,
+    languageCodes
+  };
+}
+function setLanguage(language) {
+  return {
+    type: SET_LANGUAGE,
+    language
+  };
+}
+
+function fetchLanguages(organisation_id) {
+  return (dispatch) => {
+    apiClient
+    .type('translations')
+    .get({
+      translated_type: 'Organization',
+      translated_id: organisation_id
+    })
+    .then((resources) => {
+      dispatch({
+        type: FETCH_LANGUAGES_SUCCESS,
+        payload: {
+          languageCodes: resources.map(resource => resource.language)
+        }
+      });
+    });
+  };
+}
+
+function fetchOrganisation(id) {
+  return (dispatch) => {
+    dispatch({
+      type: FETCH_ORGANISATION
+    });
+    const query = {
+      id,
+      current_user_roles: ALLOWED_ROLES
+    };
+    apiClient.type('organizations').get(query)
+    .then(([organisation]) => {
+      dispatch({
+        type: FETCH_ORGANISATION_SUCCESS,
+        payload: {
+          data: organisation,
+          primary_language: organisation.primary_language,
+          loading: false
+        }
+      });
+    });
+  };
+}
+
+// Exports
+export default organisationReducer;
+
+export {
+  fetchOrganisation,
+  addLanguage,
+  setLanguage,
+  fetchLanguages
+};

--- a/src/ducks/organisations.js
+++ b/src/ducks/organisations.js
@@ -1,0 +1,54 @@
+import apiClient from 'panoptes-client/lib/api-client';
+
+const ALLOWED_ROLES = ['owner', 'collaborator', 'translator'];
+
+// Action Types
+export const FETCH_ORGANISATIONS = 'FETCH_ORGANISATIONS';
+export const FETCH_ORGANISATIONS_SUCCESS = 'FETCH_ORGANISATIONS_SUCCESS';
+export const FETCH_ORGANISATIONS_ERROR = 'FETCH_ORGANISATIONS_ERROR';
+
+// Reducer
+const initialState = {
+  data: [],
+  error: false,
+  loading: false
+};
+
+function organisationsReducer(state = initialState, action) {
+  switch (action.type) {
+    case FETCH_ORGANISATIONS:
+      return Object.assign({}, initialState, { loading: true });
+    case FETCH_ORGANISATIONS_SUCCESS:
+      return Object.assign({}, state, { data: action.payload, loading: false });
+    case FETCH_ORGANISATIONS_ERROR:
+      return Object.assign({}, state, { error: action.payload, loading: false });
+    default:
+      return state;
+  }
+}
+
+// Action Creators
+function fetchOrganisations() {
+  return (dispatch) => {
+    dispatch({
+      type: FETCH_ORGANISATIONS
+    });
+    const query = {
+      current_user_roles: ALLOWED_ROLES
+    };
+    apiClient.type('organizations').get(query)
+    .then((organisations) => {
+      dispatch({
+        type: FETCH_ORGANISATIONS_SUCCESS,
+        payload: organisations
+      });
+    });
+  };
+}
+
+// Exports
+export default organisationsReducer;
+
+export {
+  fetchOrganisations
+};

--- a/src/ducks/reducer.js
+++ b/src/ducks/reducer.js
@@ -1,11 +1,15 @@
 import { combineReducers } from 'redux';
 import login from './login';
+import organisation from './organisation';
+import organisations from './organisations';
 import project from './project';
 import projects from './projects';
 import resource from './resource';
 
 export default combineReducers({
   login,
+  organisation,
+  organisations,
   project,
   projects,
   resource

--- a/src/ducks/resource.js
+++ b/src/ducks/resource.js
@@ -74,7 +74,7 @@ function resetTranslations() {
   };
 }
 
-function fetchTranslations(translated_id, type, project, language) {
+function fetchTranslations(translated_id, type, primary_language, language) {
   const translated_type = type || 'project';
   return (dispatch) => {
     dispatch({
@@ -83,7 +83,6 @@ function fetchTranslations(translated_id, type, project, language) {
     });
     apiClient.type('translations').get({ translated_type, translated_id })
     .then((resources) => {
-      const { primary_language } = project;
       const { original, translations } = filterResources(resources, primary_language);
       dispatch({
         type: FETCH_TRANSLATIONS_SUCCESS,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -10,6 +10,8 @@ import configureStore from './store';
 import ResourceContainer from './containers/ResourceContainer';
 import ProjectDashboardContainer from './containers/ProjectDashboardContainer';
 import ProjectDashboard from './components/ProjectDashboard';
+import OrganisationDashboardContainer from './containers/OrganisationDashboardContainer';
+import OrganisationDashboard from './components/OrganisationDashboard';
 import Home from './components/Home';
 import Resource from './components/Resource';
 
@@ -31,6 +33,9 @@ oauth.init(config.panoptesAppId)
               <Route path=":resource_type/" component={ResourceContainer}>
                 <Route path=":resource_id" component={Resource} />
               </Route>
+            </Route>
+            <Route path="/organization/:organization_id" component={OrganisationDashboardContainer}>
+              <IndexRoute component={OrganisationDashboard} />
             </Route>
           </Route>
         </Router>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -10,7 +10,7 @@ import configureStore from './store';
 import ProjectContentsContainer from './containers/ProjectContentsContainer';
 import ProjectDashboardContainer from './containers/ProjectDashboardContainer';
 import ProjectDashboard from './components/ProjectDashboard';
-import ProjectList from './containers/ProjectListContainer';
+import Home from './components/Home';
 import Resource from './components/Resource';
 
 // Todo: let's find a better way to include Styles,
@@ -25,7 +25,7 @@ oauth.init(config.panoptesAppId)
       <Provider store={store}>
         <Router history={hashHistory}>
           <Route path="/" component={App}>
-            <IndexRoute component={ProjectList} />
+            <IndexRoute component={Home} />
             <Route path="/project/:project_id" component={ProjectDashboardContainer}>
               <IndexRoute component={ProjectDashboard} />
               <Route path=":resource_type/" component={ProjectContentsContainer}>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -7,7 +7,7 @@ import oauth from 'panoptes-client/lib/oauth';
 import App from './components/App';
 import config from './constants/config';
 import configureStore from './store';
-import ProjectContentsContainer from './containers/ProjectContentsContainer';
+import ResourceContainer from './containers/ResourceContainer';
 import ProjectDashboardContainer from './containers/ProjectDashboardContainer';
 import ProjectDashboard from './components/ProjectDashboard';
 import Home from './components/Home';
@@ -28,7 +28,7 @@ oauth.init(config.panoptesAppId)
             <IndexRoute component={Home} />
             <Route path="/project/:project_id" component={ProjectDashboardContainer}>
               <IndexRoute component={ProjectDashboard} />
-              <Route path=":resource_type/" component={ProjectContentsContainer}>
+              <Route path=":resource_type/" component={ResourceContainer}>
                 <Route path=":resource_id" component={Resource} />
               </Route>
             </Route>


### PR DESCRIPTION
Closes #117.

Adds a new dashboard page for organisations, and an editor for the organisation resource. Adds actions for fetching organisations from Panoptes.

Staged at https://pandora.zooniverse.org