### PR TITLE
Add admin mode

### DIFF
--- a/src/containers/AdminContainer.jsx
+++ b/src/containers/AdminContainer.jsx
@@ -27,6 +27,8 @@ export class AdminContainer extends React.Component {
   }
 
   setAdminState(isAdmin) {
+    const { user } = this.props;
+    isAdmin = user.admin && isAdmin;
     apiClient.update({
       'params.admin': isAdmin || undefined,
     });
@@ -41,7 +43,8 @@ export class AdminContainer extends React.Component {
   }
 
   toggleAdminMode(e) {
-    const isAdmin = e.target.checked;
+    const { user } = this.props;
+    const isAdmin = user.admin && e.target.checked;
     this.setAdminState(isAdmin);
   }
 

--- a/src/containers/AdminContainer.jsx
+++ b/src/containers/AdminContainer.jsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { CheckBox } from 'grommet';
+import apiClient from 'panoptes-client/lib/api-client';
+import { setAdminMode } from '../ducks/login';
+
+export class AdminContainer extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.setAdminState = this.setAdminState.bind(this);
+    this.toggleAdminMode = this.toggleAdminMode.bind(this);
+  }
+
+  componentDidMount() {
+    const isAdmin = !!localStorage.getItem('adminFlag');
+    if (isAdmin) {
+      this.setAdminState(isAdmin);
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.adminMode !== this.props.adminMode) {
+      this.setAdminState(nextProps.adminMode);
+    }
+  }
+
+  setAdminState(isAdmin) {
+    apiClient.update({
+      'params.admin': isAdmin || undefined,
+    });
+
+    if (isAdmin) {
+      localStorage.setItem('adminFlag', true);
+    } else {
+      localStorage.removeItem('adminFlag');
+    }
+
+    this.props.dispatch(setAdminMode(isAdmin));
+  }
+
+  toggleAdminMode(e) {
+    const isAdmin = e.target.checked;
+    this.setAdminState(isAdmin);
+  }
+
+  render() {
+    if (this.props.initialised && this.props.user && this.props.user.admin) {
+      return (
+        <CheckBox
+          checked={this.props.adminMode}
+          id="admin-checkbox"
+          name="admin-checkbox"
+          label="Admin mode"
+          onChange={this.toggleAdminMode}
+          toggle={true}
+        />
+      )
+    }
+
+    return null;
+  }
+
+}
+
+AdminContainer.defaultProps = {
+  adminMode: false,
+  dispatch: () => {},
+  initialised: false,
+  user: null,
+};
+
+AdminContainer.propTypes = {
+  adminMode: PropTypes.bool,
+  dispatch: PropTypes.func,
+  initialised: PropTypes.bool,
+  user: PropTypes.shape({
+    id: PropTypes.string,
+    admin: PropTypes.bool,
+  }),
+};
+
+function mapStateToProps(state) {
+  return {
+    adminMode: state.login.adminMode,
+    initialised: state.login.initialised,
+    user: state.login.user,
+  };
+}
+
+export default connect(mapStateToProps)(AdminContainer);

--- a/src/containers/AuthContainer.jsx
+++ b/src/containers/AuthContainer.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { checkLoginUser, loginToPanoptes, logoutFromPanoptes } from '../ducks/login';
 
+import AdminToggle from './AdminContainer';
 import LoginButton from '../components/LoginButton';
 import LogoutButton from '../components/LogoutButton';
 
@@ -26,7 +27,12 @@ class AuthContainer extends React.Component {
 
   render() {
     return (this.props.user)
-      ? <LogoutButton user={this.props.user} logout={this.logout} />
+      ? (
+        <React.Fragment>
+          <LogoutButton user={this.props.user} logout={this.logout} />
+          <AdminToggle user={this.props.user} />
+        </React.Fragment>
+      )
       : <LoginButton login={this.login} />;
   }
 }

--- a/src/containers/ProjectDashboardContainer.jsx
+++ b/src/containers/ProjectDashboardContainer.jsx
@@ -19,9 +19,9 @@ class ProjectDashboardContainer extends Component {
   }
 
   componentDidMount() {
-    const { actions, params } = this.props;
+    const { actions, adminMode, params } = this.props;
     const { query } = this.props.location;
-    actions.fetchProject(params.project_id);
+    actions.fetchProject(params.project_id, adminMode);
     actions.fetchLanguages(params.project_id);
     if (query.language) {
       const language = languages.filter(option => option.value === query.language)[0];
@@ -78,8 +78,7 @@ class ProjectDashboardContainer extends Component {
 }
 
 const mapStateToProps = state => ({
-  language: state.language,
-  languages: state.languages,
+  adminMode: state.login.adminMode,
   project: state.project,
   resource: state.resource
 });
@@ -96,6 +95,7 @@ const mapDispatchToProps = dispatch => ({
 ProjectDashboardContainer.propTypes = {
   actions: PropTypes.objectOf(PropTypes.func).isRequired,
   children: PropTypes.node,
+  isAdmin: PropTypes.bool,
   location: PropTypes.shape({
     query: PropTypes.object
   }),
@@ -118,6 +118,7 @@ ProjectDashboardContainer.propTypes = {
 
 ProjectDashboardContainer.defaultProps = {
   children: null,
+  isAdmin: false,
   location: {},
   project: {
     data: null,

--- a/src/ducks/login.js
+++ b/src/ducks/login.js
@@ -2,20 +2,28 @@ import oauth from 'panoptes-client/lib/oauth';
 
 // Action Types
 const SET_LOGIN_USER = 'project/user/SET_LOGIN_USER';
+const SET_ADMIN_MODE = 'project/user/SET_ADMIN_MODE';
 
 // Reducer
 const initialState = {
+  adminMode: false,
   user: null,
   initialised: false
 };
 
 function loginReducer(state = initialState, action) {
   switch (action.type) {
-    case SET_LOGIN_USER:
+    case SET_LOGIN_USER: {
       return {
+        adminMode: false,
         user: action.user,  // null if logged out.
         initialised: true  // true once we know if user is logged in/out; false if unknown.
       };
+    }
+    case SET_ADMIN_MODE: {
+      const { adminMode } = action;
+      return Object.assign({}, state, { adminMode });
+    }
     default:
       return state;
   }
@@ -55,6 +63,13 @@ function setLoginUser(user) {
   };
 }
 
+function setAdminMode(adminMode) {
+  return {
+    type: SET_ADMIN_MODE,
+    adminMode
+  };
+}
+
 // Helper functions
 function computeRedirectURL(window) {
   const { location } = window;
@@ -69,5 +84,6 @@ export {
   checkLoginUser,
   loginToPanoptes,
   logoutFromPanoptes,
-  setLoginUser
+  setLoginUser,
+  setAdminMode
 };

--- a/src/ducks/project.js
+++ b/src/ducks/project.js
@@ -100,15 +100,14 @@ function fetchLanguages(project_id) {
   };
 }
 
-function fetchProject(id) {
+function fetchProject(id, isAdmin) {
   return (dispatch) => {
     dispatch({
       type: FETCH_PROJECT
     });
-    const query = {
-      id,
-      current_user_roles: ALLOWED_ROLES,
-      include: ['workflows']
+    let query = { id };
+    if (!isAdmin) {
+      query.current_user_roles = ALLOWED_ROLES;
     };
     apiClient.type('projects').get(query)
     .then(([project]) => {


### PR DESCRIPTION
Closes #61.

Add an admin toggle to the header, for admin users.
Add admin=true to all API requests when the toggle is on.

To do:
- [ ] Remove user role restrictions from request queries for admins.