### PR TITLE
Build with node 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js: "10.0.0"
-
-script:
-  - npm run test-travis

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:14
 
 WORKDIR /src
 RUN chown -R node:node /src

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
     "webpack-dev-server": "^3.11.0"
   },
   "engines": {
-    "node": "^10.0.0",
-    "npm": "^6.0.0"
+    "node": ">=10",
+    "npm": ">=6"
   },
   "license": "Apache-2.0",
   "repository": "https://github.com/zooniverse/pandora",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
Use a node:14 image to run builds. Note that builds fail with node:14-alpine because gcc isn't installed.