### PR TITLE
Edit empty fields

### DIFF
--- a/src/components/TranslationField.jsx
+++ b/src/components/TranslationField.jsx
@@ -37,6 +37,7 @@ class TranslationField extends React.Component {
     const languageCode = language ? language.value : undefined;
     const originalFormatted = isMarkdown ? <Markdown>{original}</Markdown> : <p>{original}</p>;
     const translationFormatted = isMarkdown ? <Markdown>{translation}</Markdown> : <p>{translation}</p>;
+    const hasText = original?.length > 0 || translation?.length > 0
 
     return (
       <Box className="field-editor">
@@ -56,7 +57,7 @@ class TranslationField extends React.Component {
             </Heading>
           </Box>
           <Box>
-            {(!editing && original && original.length > 0) &&
+            {(!editing && hasText) &&
               <Button
                 fill={false}
                 icon={<FormEdit size="small" />}


### PR DESCRIPTION
Allow editing of empty fields if either the original has text or the translation has text. This should allow editing in the case where a project owner removes the original, but a translation still exists.

https://pandora.zooniverse.org/#/project/908?language=es
![Screenshot of the project translation editor, showing that the Spanish workflow description can still be edited even though the English original has been removed.](https://user-images.githubusercontent.com/59547/105039239-3784bd00-5a58-11eb-8560-bb8c66109309.png)

Fixes #175.