### PR TITLE
[Security] Use shared workflows to build & deploy

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -6,109 +6,33 @@ on:
         tags:
           - production-release
 
-    # Allow running this workflow manually from the Actions tab
-    workflow_dispatch:
-
 jobs:
-  deploy_production:
-    runs-on: ubuntu-latest
-    env:
-      HEAD_COMMIT: ${{ github.sha }}
-    steps:
-    - uses: actions/checkout@v2
-    - uses: azure/login@v1
-      with:
-          creds: ${{ secrets.AZURE_STATIC_SITES }}
-
-    - name: Node.js build
-      id: build
-      uses: actions/setup-node@v1
-      with:
-        node-version: '16.x'
-
-    - name: Cache dependencies
-      uses: actions/cache@v1
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
-
-    - run: npm ci
-    - run: npm run _build-production
-
-    - name: Write commit_id.txt
-      run: echo ${HEAD_COMMIT} > ./dist/commit_id.txt
-
-    - name: Upload to blob storage
-      uses: azure/CLI@v1
-      with:
-        creds: ${{ secrets.AZURE_STATIC_SITES }}
-        inlineScript: |
-            az storage blob upload \
-              --account-name zooniversestatic \
-              --content-cache-control 'public, max-age=60, s-maxage=60' \
-              --container-name '$web' \
-              --name 'translations.zooniverse.org/index.html' \
-              --file ./dist/index.html
-            rm ./dist/index.html
-            az storage blob upload \
-              --account-name zooniversestatic \
-              --content-cache-control 'public, max-age=60, s-maxage=60' \
-              --container-name '$web' \
-              --name 'translations.zooniverse.org/commit_id.txt' \
-              --file ./dist/commit_id.txt
-            rm ./dist/commit_id.txt
-            az storage blob upload-batch \
-              --account-name zooniversestatic \
-              --content-cache-control 'public, immutable, max-age=604800' \
-              --destination '$web/translations.zooniverse.org' \
-              --source ./dist
-
-    - name: Slack notification
-      uses: 8398a7/action-slack@v3
-      if: always()
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      with:
-        fields: took
-        status: custom
-        custom_payload: |
-          {
-            "channel": "#deploys",
-            "icon_emoji": ":octocat:",
-            "username": "Deploy Action",
-            "attachments": [{
-              "color": '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
-              "mrkdwn_in": ["text"],
-              "author_name": "${{ github.actor }}",
-              "author_link": "https://github.com/${{ github.actor }}/",
-              "author_icon": "https://github.com/${{ github.actor }}.png?size=40",
-              "title": "Translations Production deploy complete",
-              "title_link": "https://translations.zooniverse.org",
-              "fields": [
-                  {
-                      "title": "Status",
-                      "value": '${{ job.status }}' === 'success' ? `:white_check_mark: Success in ${process.env.AS_TOOK}` : '${{ job.status }}' === 'failure' ? ':x: Failed' : ':warning: Warning',
-                      "short": true
-                  },
-                  {
-                      "title": "Triggered by",
-                      "value": "${{ github.event_name }}",
-                      "short": true
-                  },
-                  {
-                      "title": "Run Link",
-                      "value": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                  }
-              ],
-              "thumb_url": "https://raw.githubusercontent.com/zooniverse/Brand/master/style%20guide/logos/zooniverse-emblem/zooniverse-logo-teal.png",
-              "footer": "<https://github.com/${{ github.repository }}|${{ github.repository }}> #${{ github.run_number }}",
-              "footer_icon": "https://www.zooniverse.org/favicon.ico"
-            }]
-          }
-
-# Azure logout
-    - name: logout
-      run: |
-            az logout
+  build:
+    uses: zooniverse/ci-cd/.github/workflows/npm_build.yaml@main
+    with:
+      commit_id: ${{ github.sha }}
+      node_version: '16.x'
+      output: 'dist'
+      script: '_build-production'
+  deploy:
+    name: Deploy production
+    uses: zooniverse/ci-cd/.github/workflows/deploy_static.yaml@main
+    needs: build
+    with:
+      source: 'dist'
+      target: 'translations.zooniverse.org'
+    secrets:
+      creds: ${{ secrets.AZURE_STATIC_SITES }}
+  slack_notifiaction:
+    name: Send Slack notification
+    uses: zooniverse/ci-cd/.github/workflows/slack_notification.yaml@main
+    needs: deploy
+    if: always()
+    with:
+      commit_id: ${{ github.sha }}
+      job_name: Build production / build
+      status: ${{ needs.deploy.result }}
+      title: 'Translations Production deploy complete'
+      title_link: 'https://translations.zooniverse.org'
+    secrets:
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -5,109 +5,33 @@ on:
     push:
         branches: [ master ]
 
-    # Allow running this workflow manually from the Actions tab
-    workflow_dispatch:
-
 jobs:
-  deploy_staging_branch:
-    runs-on: ubuntu-latest
-    env:
-      HEAD_COMMIT: ${{ github.sha }}
-    steps:
-    - uses: actions/checkout@v2
-    - uses: azure/login@v1
-      with:
-          creds: ${{ secrets.AZURE_STATIC_SITES }}
-
-    - name: Node.js build
-      id: build
-      uses: actions/setup-node@v1
-      with:
-        node-version: '16.x'
-
-    - name: Cache dependencies
-      uses: actions/cache@v1
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
-
-    - run: npm ci
-    - run: npm run _build-staging
-
-    - name: Write commit_id.txt
-      run: echo ${HEAD_COMMIT} > ./dist/commit_id.txt
-
-    - name: Upload to blob storage
-      uses: azure/CLI@v1
-      with:
-        creds: ${{ secrets.AZURE_STATIC_SITES }}
-        inlineScript: |
-            az storage blob upload \
-              --account-name zooniversestatic \
-              --content-cache-control 'public, max-age=60, s-maxage=60' \
-              --container-name '$web' \
-              --name 'pandora.zooniverse.org/index.html' \
-              --file ./dist/index.html
-            rm ./dist/index.html
-            az storage blob upload \
-              --account-name zooniversestatic \
-              --content-cache-control 'public, max-age=60, s-maxage=60' \
-              --container-name '$web' \
-              --name 'pandora.zooniverse.org/commit_id.txt' \
-              --file ./dist/commit_id.txt
-            rm ./dist/commit_id.txt
-            az storage blob upload-batch \
-              --account-name zooniversestatic \
-              --content-cache-control 'public, immutable, max-age=604800' \
-              --destination '$web/pandora.zooniverse.org' \
-              --source ./dist
-
-    - name: Slack notification
-      uses: 8398a7/action-slack@v3
-      if: always()
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      with:
-        fields: took
-        status: custom
-        custom_payload: |
-          {
-            "channel": "#deploys",
-            "icon_emoji": ":octocat:",
-            "username": "Deploy Action",
-            "attachments": [{
-              "color": '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
-              "mrkdwn_in": ["text"],
-              "author_name": "${{ github.actor }}",
-              "author_link": "https://github.com/${{ github.actor }}/",
-              "author_icon": "https://github.com/${{ github.actor }}.png?size=40",
-              "title": "Pandora Staging deploy complete",
-              "title_link": "https://pandora.zooniverse.org",
-              "fields": [
-                  {
-                      "title": "Status",
-                      "value": '${{ job.status }}' === 'success' ? `:white_check_mark: Success in ${process.env.AS_TOOK}` : '${{ job.status }}' === 'failure' ? ':x: Failed' : ':warning: Warning',
-                      "short": true
-                  },
-                  {
-                      "title": "Triggered by",
-                      "value": "${{ github.event_name }}",
-                      "short": true
-                  },
-                  {
-                      "title": "Run Link",
-                      "value": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                  }
-              ],
-              "thumb_url": "https://raw.githubusercontent.com/zooniverse/Brand/master/style%20guide/logos/zooniverse-emblem/zooniverse-logo-teal.png",
-              "footer": "<https://github.com/${{ github.repository }}|${{ github.repository }}> #${{ github.run_number }}",
-              "footer_icon": "https://www.zooniverse.org/favicon.ico"
-            }]
-          }
-
-# Azure logout
-    - name: logout
-      run: |
-            az logout
+  build:
+    uses: zooniverse/ci-cd/.github/workflows/npm_build.yaml@main
+    with:
+      commit_id: ${{ github.sha }}
+      node_version: '16.x'
+      output: 'dist'
+      script: '_build-staging'
+  deploy:
+    name: Deploy staging
+    uses: zooniverse/ci-cd/.github/workflows/deploy_static.yaml@main
+    needs: build
+    with:
+      source: 'dist'
+      target: 'pandora.zooniverse.org'
+    secrets:
+      creds: ${{ secrets.AZURE_STATIC_SITES }}
+  slack_notifiaction:
+    name: Send Slack notification
+    uses: zooniverse/ci-cd/.github/workflows/slack_notification.yaml@main
+    needs: deploy
+    if: always()
+    with:
+      commit_id: ${{ github.sha }}
+      job_name: Build staging / build
+      status: ${{ needs.deploy.result }}
+      title: 'Pandora Staging deploy complete'
+      title_link: 'https://pandora.zooniverse.org'
+    secrets:
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Use shared workflows from `zooniverse/ci-cd` for builds. Split deployment into three jobs: build, deploy and notify. Azure secrets are only shared with the deploy job.

Closes #197.