### PR TITLE
Remove `bindActionCreators` from components

### DIFF
--- a/src/components/TranslationEditor.jsx
+++ b/src/components/TranslationEditor.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import Box from 'grommet/components/Box';
 import Button from 'grommet/components/Button';
 import { Markdown, MarkdownEditor } from 'markdownz';
-import * as contentsActions from '../ducks/resource';
+import { updateTranslation } from '../ducks/resource';
 
 class TranslationEditor extends React.Component {
   constructor(props) {
@@ -14,9 +13,10 @@ class TranslationEditor extends React.Component {
     this.state = { translationText };
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.translation !== this.props.translation) {
-      const translationText = nextProps.translation ? nextProps.translation : nextProps.original;
+  componentDidUpdate(prevProps) {
+    const { original, translation } = this.props;
+    if (prevProps.translation !== translation) {
+      const translationText = translation || original;
       this.setState({ translationText });
     }
   }
@@ -29,9 +29,9 @@ class TranslationEditor extends React.Component {
 
   save(event) {
     event.preventDefault();
-    const { actions, resource, translationKey } = this.props;
+    const { dispatch, resource, translationKey } = this.props;
     const { translationText } = this.state;
-    actions.updateTranslation(resource.original, resource.translation, translationKey, translationText);
+    dispatch(updateTranslation(resource.original, resource.translation, translationKey, translationText));
     this.props.onSave(event);
   }
 
@@ -129,9 +129,6 @@ TranslationEditor.defaultProps = {
 const mapStateToProps = state => ({
   resource: state.resource
 });
-const mapDispatchToProps = dispatch => ({
-  actions: bindActionCreators(contentsActions, dispatch)
-});
 
-export default connect(mapStateToProps, mapDispatchToProps)(TranslationEditor);
+export default connect(mapStateToProps)(TranslationEditor);
 export { TranslationEditor };

--- a/src/containers/AdminContainer.jsx
+++ b/src/containers/AdminContainer.jsx
@@ -20,9 +20,9 @@ export class AdminContainer extends React.Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.adminMode !== this.props.adminMode) {
-      this.setAdminState(nextProps.adminMode);
+  componentDidUpdate(prevProps) {
+    if (prevProps.adminMode !== this.props.adminMode) {
+      this.setAdminState(this.props.adminMode);
     }
   }
 
@@ -30,7 +30,7 @@ export class AdminContainer extends React.Component {
     const { user } = this.props;
     isAdmin = user.admin && isAdmin;
     apiClient.update({
-      'params.admin': isAdmin || undefined,
+      'params.admin': isAdmin || undefined
     });
 
     if (isAdmin) {
@@ -57,9 +57,9 @@ export class AdminContainer extends React.Component {
           name="admin-checkbox"
           label="Admin mode"
           onChange={this.toggleAdminMode}
-          toggle={true}
+          toggle
         />
-      )
+      );
     }
 
     return null;
@@ -71,7 +71,7 @@ AdminContainer.defaultProps = {
   adminMode: false,
   dispatch: () => {},
   initialised: false,
-  user: null,
+  user: null
 };
 
 AdminContainer.propTypes = {
@@ -80,15 +80,15 @@ AdminContainer.propTypes = {
   initialised: PropTypes.bool,
   user: PropTypes.shape({
     id: PropTypes.string,
-    admin: PropTypes.bool,
-  }),
+    admin: PropTypes.bool
+  })
 };
 
 function mapStateToProps(state) {
   return {
     adminMode: state.login.adminMode,
     initialised: state.login.initialised,
-    user: state.login.user,
+    user: state.login.user
   };
 }
 

--- a/src/containers/OrganisationDashboardContainer.jsx
+++ b/src/containers/OrganisationDashboardContainer.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { Link } from 'react-router';
 import LanguageSelector from '../components/LanguageSelector';
 import { fetchOrganisation, addLanguage, setLanguage, fetchLanguages } from '../ducks/organisation';
@@ -19,24 +18,24 @@ class OrganisationDashboardContainer extends Component {
   }
 
   componentDidMount() {
-    const { actions, adminMode, params } = this.props;
+    const { dispatch, adminMode, params } = this.props;
     const { query } = this.props.location;
-    actions.fetchOrganisation(params.organization_id, adminMode);
-    actions.fetchLanguages(params.organization_id);
+    dispatch(fetchOrganisation(params.organization_id, adminMode));
+    dispatch(fetchLanguages(params.organization_id));
     if (query.language) {
       const language = languages.filter(option => option.value === query.language)[0];
-      actions.setLanguage(language);
+      dispatch(setLanguage(language));
     }
   }
 
   onChangeLanguage(option) {
-    const { actions } = this.props;
+    const { dispatch } = this.props;
     const { languageCodes } = this.props.organisation;
     if (languageCodes.indexOf(option.value) === -1) {
       languageCodes.push(option.value);
-      actions.addLanguage(languageCodes);
+      dispatch(addLanguage(languageCodes));
     }
-    actions.setLanguage(option);
+    dispatch(setLanguage(option));
   }
 
   render() {
@@ -84,15 +83,6 @@ const mapStateToProps = state => ({
   organisation: state.organisation,
   resource: state.resource
 });
-const mapDispatchToProps = dispatch => ({
-  actions: {
-    fetchOrganisation: bindActionCreators(fetchOrganisation, dispatch),
-    addLanguage: bindActionCreators(addLanguage, dispatch),
-    setLanguage: bindActionCreators(setLanguage, dispatch),
-    createTranslation: bindActionCreators(createTranslation, dispatch),
-    fetchLanguages: bindActionCreators(fetchLanguages, dispatch)
-  }
-});
 
 OrganisationDashboardContainer.propTypes = {
   actions: PropTypes.objectOf(PropTypes.func).isRequired,
@@ -126,7 +116,4 @@ OrganisationDashboardContainer.defaultProps = {
     primary_language: 'en'
   }
 };
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(OrganisationDashboardContainer);
+export default connect(mapStateToProps)(OrganisationDashboardContainer);

--- a/src/containers/OrganisationListContainer.jsx
+++ b/src/containers/OrganisationListContainer.jsx
@@ -1,17 +1,16 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
-import * as organisationsActions from '../ducks/organisations';
+import { fetchOrganisations } from '../ducks/organisations';
 
 import OrganisationList from '../components/OrganisationList';
 
 class OrganisationListContainer extends Component {
 
   componentDidMount() {
-    const { actions } = this.props;
-    actions.fetchOrganisations();
+    const { dispatch } = this.props;
+    dispatch(fetchOrganisations());
   }
 
   render() {
@@ -24,10 +23,6 @@ class OrganisationListContainer extends Component {
 
 const mapStateToProps = state => ({
   organisations: state.organisations
-});
-
-const mapDispatchToProps = dispatch => ({
-  actions: bindActionCreators(organisationsActions, dispatch)
 });
 
 OrganisationListContainer.propTypes = {
@@ -43,7 +38,4 @@ OrganisationListContainer.defaultProps = {
   }
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(OrganisationListContainer);
+export default connect(mapStateToProps)(OrganisationListContainer);

--- a/src/containers/ProjectDashboardContainer.jsx
+++ b/src/containers/ProjectDashboardContainer.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { Link } from 'react-router';
 import LanguageSelector from '../components/LanguageSelector';
 import { fetchProject, addLanguage, setLanguage, fetchLanguages } from '../ducks/project';
@@ -19,24 +18,24 @@ class ProjectDashboardContainer extends Component {
   }
 
   componentDidMount() {
-    const { actions, adminMode, params } = this.props;
+    const { dispatch, adminMode, params } = this.props;
     const { query } = this.props.location;
-    actions.fetchProject(params.project_id, adminMode);
-    actions.fetchLanguages(params.project_id);
+    dispatch(fetchProject(params.project_id, adminMode));
+    dispatch(fetchLanguages(params.project_id));
     if (query.language) {
       const language = languages.filter(option => option.value === query.language)[0];
-      actions.setLanguage(language);
+      dispatch(setLanguage(language));
     }
   }
 
   onChangeLanguage(option) {
-    const { actions } = this.props;
+    const { dispatch } = this.props;
     const { languageCodes } = this.props.project;
     if (languageCodes.indexOf(option.value) === -1) {
       languageCodes.push(option.value);
-      actions.addLanguage(languageCodes);
+      dispatch(addLanguage(languageCodes));
     }
-    actions.setLanguage(option);
+    dispatch(setLanguage(option));
   }
 
   render() {
@@ -82,15 +81,6 @@ const mapStateToProps = state => ({
   project: state.project,
   resource: state.resource
 });
-const mapDispatchToProps = dispatch => ({
-  actions: {
-    fetchProject: bindActionCreators(fetchProject, dispatch),
-    addLanguage: bindActionCreators(addLanguage, dispatch),
-    setLanguage: bindActionCreators(setLanguage, dispatch),
-    createTranslation: bindActionCreators(createTranslation, dispatch),
-    fetchLanguages: bindActionCreators(fetchLanguages, dispatch)
-  }
-});
 
 ProjectDashboardContainer.propTypes = {
   actions: PropTypes.objectOf(PropTypes.func).isRequired,
@@ -128,7 +118,4 @@ ProjectDashboardContainer.defaultProps = {
     workflows: []
   }
 };
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(ProjectDashboardContainer);
+export default connect(mapStateToProps)(ProjectDashboardContainer);

--- a/src/containers/ProjectListContainer.jsx
+++ b/src/containers/ProjectListContainer.jsx
@@ -1,17 +1,16 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
-import * as projectsActions from '../ducks/projects';
+import { fetchProjects } from '../ducks/projects';
 
 import ProjectList from '../components/ProjectList';
 
 class ProjectListContainer extends Component {
 
   componentDidMount() {
-    const { actions } = this.props;
-    actions.fetchProjects();
+    const { dispatch } = this.props;
+    dispatch(fetchProjects());
   }
 
   render() {
@@ -24,10 +23,6 @@ class ProjectListContainer extends Component {
 
 const mapStateToProps = state => ({
   projects: state.projects
-});
-
-const mapDispatchToProps = dispatch => ({
-  actions: bindActionCreators(projectsActions, dispatch)
 });
 
 ProjectListContainer.propTypes = {
@@ -43,7 +38,4 @@ ProjectListContainer.defaultProps = {
   }
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(ProjectListContainer);
+export default connect(mapStateToProps)(ProjectListContainer);

--- a/src/containers/ResourceContainer.jsx
+++ b/src/containers/ResourceContainer.jsx
@@ -1,33 +1,32 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-import * as contentsActions from '../ducks/resource';
+import { fetchTranslations, resetErrors, resetTranslations, selectTranslations } from '../ducks/resource';
 
 class ResourceContainer extends Component {
 
-  componentWillMount() {
-    const { actions } = this.props;
-    actions.resetTranslations();
+  componentDidMount() {
+    const { dispatch } = this.props;
+    dispatch(resetTranslations());
   }
 
   componentDidMount() {
-    const { actions, params, primary_language, language } = this.props;
+    const { dispatch, params, primary_language, language } = this.props;
     const { resource_id, resource_type } = params;
-    actions.fetchTranslations(resource_id, resource_type, primary_language, language);
+    dispatch(fetchTranslations(resource_id, resource_type, primary_language, language));
   }
 
-  componentWillReceiveProps(newProps) {
-    const { actions, params, resource, language } = newProps;
-    if (newProps.language !== this.props.language && newProps.language.value !== newProps.primary_language) {
+  componentDidUpdate(prevProps) {
+    const { dispatch, params, resource, language, primary_language } = this.props;
+    if (prevProps.language !== language && language.value !== primary_language) {
       const { resource_type } = params;
       const { original, translations } = resource;
-      actions.selectTranslation(original, translations, resource_type, language);
+      dispatch(selectTranslation(original, translations, resource_type, language));
     }
-    if (newProps.resource.error) {
-      const { message, status, statusText } = newProps.resource.error;
+    if (resource.error) {
+      const { message, status, statusText } = resource.error;
       alert(`${status}: ${statusText}\n ${message}`);
-      actions.resetErrors();
+      dispatch(resetErrors());
     }
   }
 
@@ -39,9 +38,6 @@ class ResourceContainer extends Component {
 
 const mapStateToProps = state => ({
   resource: state.resource
-});
-const mapDispatchToProps = dispatch => ({
-  actions: bindActionCreators(contentsActions, dispatch)
 });
 
 ResourceContainer.propTypes = {
@@ -68,7 +64,4 @@ ResourceContainer.defaultProps = {
   primary_language: 'en'
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(ResourceContainer);
+export default connect(mapStateToProps)(ResourceContainer);


### PR DESCRIPTION
Connected components [shouldn't need to bind action creators](https://redux.js.org/api/bindactioncreators/), so this removes `bindActionCreators` and dispatches actions directly in event handlers and during lifecycle methods.

Older components that used `componentWillReceiveProps` have also been updated to use `componentDidUpdate`.