### PR TITLE
Update panoptes-client to v4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "grommet": "^1.13.0",
         "history": "^5.3.0",
         "markdownz": "^7.8.2",
-        "panoptes-client": "^4.0.0",
+        "panoptes-client": "^4.1.0",
         "prop-types": "^15.7.2",
         "react": "~16.14.0",
         "react-dom": "~16.14.0",
@@ -14802,9 +14802,9 @@
       "dev": true
     },
     "node_modules/panoptes-client": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.0.0.tgz",
-      "integrity": "sha512-hPdWcQGAQl8atDMcDTfV5IrwZz7I4uFxXNNmU4H7KnfBGm+LUGxCFshOuZjHe8OghDIiGXyirDrba2vP9N050g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.1.0.tgz",
+      "integrity": "sha512-Fg/CpqToxv45bVeiOQWBlmnBefp6KNzxbmVxhavVtfy2Pej/gPSZPtlTgeYNSkqOk8HgUFhBNgDyiQAm7I8wUg==",
       "dependencies": {
         "json-api-client": "~6.0.0",
         "local-storage": "^2.0.0",
@@ -31541,9 +31541,9 @@
       "dev": true
     },
     "panoptes-client": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.0.0.tgz",
-      "integrity": "sha512-hPdWcQGAQl8atDMcDTfV5IrwZz7I4uFxXNNmU4H7KnfBGm+LUGxCFshOuZjHe8OghDIiGXyirDrba2vP9N050g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.1.0.tgz",
+      "integrity": "sha512-Fg/CpqToxv45bVeiOQWBlmnBefp6KNzxbmVxhavVtfy2Pej/gPSZPtlTgeYNSkqOk8HgUFhBNgDyiQAm7I8wUg==",
       "requires": {
         "json-api-client": "~6.0.0",
         "local-storage": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "grommet": "^1.13.0",
     "history": "^5.3.0",
     "markdownz": "^7.8.2",
-    "panoptes-client": "^4.0.0",
+    "panoptes-client": "^4.1.0",
     "prop-types": "^15.7.2",
     "react": "~16.14.0",
     "react-dom": "~16.14.0",


### PR DESCRIPTION
Update panoptes-client to v4.1.0, including security fix.

https://github.com/zooniverse/panoptes-javascript-client/blob/master/CHANGELOG.md#v410-2022-09-30