### PR TITLE
Increase max projects fetched from default 20 to 100

### DIFF
--- a/src/ducks/projects.js
+++ b/src/ducks/projects.js
@@ -50,7 +50,8 @@ function fetchProjects() {
       type: FETCH_PROJECTS
     });
     const query = {
-      current_user_roles: ALLOWED_ROLES
+      current_user_roles: ALLOWED_ROLES,
+      page_size: 100
     };
     apiClient.type('projects').get(query)
       .then((projects) => {


### PR DESCRIPTION
## PR Overview

Fixes #627
See also: https://www.zooniverse.org/talk/17/3310256

This PR increases the maximum number of projects fetched from the API from 20 (default) to 100. This is a simple yet effective stopgap solution to the issue where users with many (i.e. > 20) projects are unable to see all their project.

A better, longer term solution would be to implement a paging system, and should be something we pursue when we have more dev time available.

### Status

Ready to go.