### PR TITLE
Add bn language code (no dialect)

### DIFF
--- a/src/constants/languages.js
+++ b/src/constants/languages.js
@@ -10,6 +10,7 @@ const languages = [
   { value: 'ba-ru', label: 'Bashkir (Russia)' },
   { value: 'eu', label: 'Basque' },
   { value: 'be', label: 'Belarusian' },
+  { value: 'bn', label: 'Bengali' },
   { value: 'bn-bd', label: 'Bengali (Bangladesh)' },
   { value: 'bn-in', label: 'Bengali (India)' },
   { value: 'bs-cyrl-ba', label: 'Bosnian (Cyrillic, Bosnia and Herzegovina)' },


### PR DESCRIPTION
Add bn language code without any dialect specification. This is a quick fix to provide options while trying to add `bn` platform level content (see https://github.com/zooniverse/Panoptes-Front-End/pull/7122). Follow-up work beyond this fix is warranted -- see #845).